### PR TITLE
Poprawka przykładu "stereogram"

### DIFF
--- a/samples/a8/graph/stereogram.pas
+++ b/samples/a8/graph/stereogram.pas
@@ -433,7 +433,7 @@ end;
 
 var
   X, Y: Word;
-  S, L: Byte;
+  S, L: Word;
 begin
   for Y := 0 to 191 do
     for X := 0 to 31 do


### PR DESCRIPTION
Program stereogram.pas przestał rysować stereogram. Zmiana typu zmiennych z Byte na Word naprawia ten problem.