### PR TITLE
zmiana kodowania z WINDOWS-1250 na UTF8

### DIFF
--- a/base/atari/players/rmt_player_sdx.asm
+++ b/base/atari/players/rmt_player_sdx.asm
@@ -1,5 +1,5 @@
 // Mono:
-// Ja tam robi≥em jakieú modyfikacje do patchowanej tabeli basÛw 0a i do
+// Ja tam robi≈Çem jakie≈õ modyfikacje do patchowanej tabeli bas√≥w 0a i do
 // playera analmuxa (sa dwa rozne).
 // Odpowiada za to zmienna patch (bajt).
 // 0=standard RMT 1.28

--- a/base/atari/resource.asm
+++ b/base/atari/resource.asm
@@ -158,28 +158,28 @@ ext_b	= $4000		;cokolwiek z zakresu $4000-$7FFF
 	lda ext_b
 	pha
 
-	ldx #$0f	;zapamiêtanie bajtów ext (z 16 bloków po 64k)
+	ldx #$0f	;zapamiÄ™tanie bajtÃ³w ext (z 16 blokÃ³w po 64k)
 _p0	jsr setpb
 	lda ext_b
 	sta bsav,x
 	dex
 	bpl _p0
 
-	ldx #$0f	;wyzerowanie ich (w oddzielnej pêtli, bo nie wiadomo
-_p1	jsr setpb	;które kombinacje bitów PORTB wybieraj¹ te same banki)
+	ldx #$0f	;wyzerowanie ich (w oddzielnej pÄ™tli, bo nie wiadomo
+_p1	jsr setpb	;ktÃ³re kombinacje bitÃ³w PORTB wybierajÄ… te same banki)
 	lda #$00
 	sta ext_b
 	dex
 	bpl _p1
 
-	stx portb	;eliminacja pamiêci podstawowej
+	stx portb	;eliminacja pamiÄ™ci podstawowej
 	stx ext_b
-	stx $00		;niezbêdne dla niektórych rozszerzeñ do 256k
+	stx $00		;niezbÄ™dne dla niektÃ³rych rozszerzeÅ„ do 256k
 
-	ldy #$00	;pêtla zliczaj¹ca bloki 64k
+	ldy #$00	;pÄ™tla zliczajÄ…ca bloki 64k
 	ldx #$0f
 _p2	jsr setpb
-	lda ext_b	;jeœli ext_b jest ró¿ne od zera, blok 64k ju¿ zliczony
+	lda ext_b	;jeÅ›li ext_b jest rÃ³Å¼ne od zera, blok 64k juÅ¼ zliczony
 	bne _n2
 
 	dec ext_b	;w przeciwnym wypadku zaznacz jako zliczony
@@ -187,9 +187,9 @@ _p2	jsr setpb
 	lda ext_b	;sprawdz, czy sie zaznaczyl; jesli nie -> cos nie tak ze sprzetem
 	bpl _n2
 
-	lda portb	;wpisz wartoœæ PORTB do tablicy dla banku 0
+	lda portb	;wpisz wartoÅ›Ä‡ PORTB do tablicy dla banku 0
 	sta @mem_banks,y
-	eor #%00000100	;uzupe³nij wartoœci dla banków 1, 2, 3
+	eor #%00000100	;uzupeÅ‚nij wartoÅ›ci dla bankÃ³w 1, 2, 3
 	sta @mem_banks+1,y
 	eor #%00001100
 	sta @mem_banks+2,y
@@ -203,7 +203,7 @@ _p2	jsr setpb
 _n2	dex
 	bpl _p2
 
-	ldx #$0f	;przywrócenie zawartoœci ext
+	ldx #$0f	;przywrÃ³cenie zawartoÅ›ci ext
 _p3	jsr setpb
 	lda bsav,x
 	sta ext_b
@@ -222,13 +222,13 @@ _p3	jsr setpb
 	rts
 
 ; podprogramy
-setpb	txa		;zmiana kolejnoœci bitów: %0000dcba -> %cba000d0
+setpb	txa		;zmiana kolejnoÅ›ci bitÃ³w: %0000dcba -> %cba000d0
 	lsr
 	ror
 	ror
 	ror
 	adc #$01	;ustawienie bitu nr 1 w zaleznosci od stanu C
-	ora #$01	;ustawienie bitu steruj¹cego OS ROM na wartosc domyslna
+	ora #$01	;ustawienie bitu sterujÄ…cego OS ROM na wartosc domyslna
 	sta portb
 	rts
 
@@ -594,7 +594,7 @@ ofset	= new_add-old_add
 
 	.get [old_add-6] :1
 
-	.put[old_add-4] = .lo(new_add)			// poprawiamy nag³ówek DOS'a
+	.put[old_add-4] = .lo(new_add)			// poprawiamy nagÅ‚Ã³wek DOS'a
 	.put[old_add-3] = .hi(new_add)			// tak aby zawieral informacje o nowym
 
 	.put[old_add-2] = .lo(new_add + length - 1)	// adresie modulu RMT

--- a/base/atari/s_vbxe/sdxld2.asm
+++ b/base/atari/s_vbxe/sdxld2.asm
@@ -654,12 +654,12 @@ E_84DC	jsr $0000
 E_84DF	jmp $0000
 
 ; http://tajemnice.atari8.info/8_91/8_91_dosy.html
-; Tablica sterownika (ang. handler) zawiera szereg wektorów o okreœlonym znaczeniu.
-; Ich kolejnoœæ jest nastêpuj¹ca:
+; Tablica sterownika (ang. handler) zawiera szereg wektorÃ³w o okreÅ›lonym znaczeniu.
+; Ich kolejnoÅ›Ä‡ jest nastÄ™pujÄ…ca:
 ;	OPEN (wektor otwarcia pliku)
-;	CLOSE (wektor zamkniêcia pliku)
-;	GET BYTE (wektor pobrania bajtu z urz¹dzenia Ÿród³owego)
-;	PUT BYTE (wektor wys³ania bajtu do peryferia)
+;	CLOSE (wektor zamkniÄ™cia pliku)
+;	GET BYTE (wektor pobrania bajtu z urzÄ…dzenia ÅºrÃ³dÅ‚owego)
+;	PUT BYTE (wektor wysÅ‚ania bajtu do peryferia)
 ;	GET STATUS (wektor pobrania statusu)
 ;	SPECIAL (wektor specjalny).
 

--- a/blibs/xbios.pas
+++ b/blibs/xbios.pas
@@ -108,7 +108,7 @@ procedure xBiosRenameEntry(var filename:TString); assembler;
 * @description:
 * This function allows you to rename a file or directory. 
 * There is no limit to the characters used in the filename apart from that they must fit 
-* a case insensitive â€ś8.3â€ť format without the dot. If your filename is not 8 characters long, 
+* a case insensitive "8.3" format without the dot. If your filename is not 8 characters long, 
 * pad it out with spaces.
 * 
 * @param: filename - string containing both names, source and destination, padded with spaces. 

--- a/blibs/xbios.pas
+++ b/blibs/xbios.pas
@@ -108,7 +108,7 @@ procedure xBiosRenameEntry(var filename:TString); assembler;
 * @description:
 * This function allows you to rename a file or directory. 
 * There is no limit to the characters used in the filename apart from that they must fit 
-* a case insensitive “8.3” format without the dot. If your filename is not 8 characters long, 
+* a case insensitive â€ś8.3â€ť format without the dot. If your filename is not 8 characters long, 
 * pad it out with spaces.
 * 
 * @param: filename - string containing both names, source and destination, padded with spaces. 

--- a/lib/cio.pas
+++ b/lib/cio.pas
@@ -1,7 +1,7 @@
 unit cio;
 (*
  @type: unit
- @author: Tomasz Biela (Tebe), Daniel KoümiÒski (Dely)
+ @author: Tomasz Biela (Tebe), Daniel Ko≈∫mi≈Ñski (Dely)
  @name: CIO interface
  @version: 1.0
 

--- a/lib/fastgraph.pas
+++ b/lib/fastgraph.pas
@@ -7,7 +7,7 @@ unit fastgraph;
 @description:
 <http://www.freepascal.org/docs-html/rtl/graph/index-5.html>
 
-Marcin ¯ukowski (Eru/TQA): fLine
+Marcin Å»ukowski (Eru/TQA): fLine
 *)
 
 

--- a/lib/fastmath.pas
+++ b/lib/fastmath.pas
@@ -37,7 +37,7 @@ function atan2(x1,x2,y1,y2: byte): byte; assembler;
 * In otherwords nothing new or particularily clever but nevertheless
 * quite useful.
 *
-* by Johan Forslöf (doynax)
+* by Johan ForslÃ¶f (doynax)
 * https://codebase64.org/doku.php?id=base:8bit_atan2_8-bit_angle
 
 @param: x1 - byte

--- a/lib/graph.inc
+++ b/lib/graph.inc
@@ -872,11 +872,11 @@ var
 begin
 
    // Algorytm Cohena-Sutherlanda
-   // 1. Zakoduj koÒce odcinka zgodnie z kodami obszarÛw
+   // 1. Zakoduj ko≈Ñce odcinka zgodnie z kodami obszar√≥w
    rcode1 := calcRegCode(x1, y1);
    rcode2 := calcRegCode(x2, y2);
-   // 2. Jeøeli iloczyn logiczny (AND) tych kodÛw <>0,
-   // to odcinek moøe byÊ pominiÍty (w ca≥oúci poza
+   // 2. Je≈ºeli iloczyn logiczny (AND) tych kod√≥w <>0,
+   // to odcinek mo≈ºe byƒá pominiƒôty (w ca≈Ço≈õci poza
    // oknem) - zaznacz go na czerwono
 //   if ((rcode1 and rcode2) <> 0) then
 //   begin
@@ -884,8 +884,8 @@ begin
 //      Image1.Canvas.MoveTo(x1, y1);
 //      Image1.Canvas.LineTo(x2, y2);
 //   end
-   // 3. Jeøeli suma logiczna (OR)tych kodÛw = 0,
-   // to odcinek w ca≥oúci mieúci siÍ w okienku
+   // 3. Je≈ºeli suma logiczna (OR)tych kod√≥w = 0,
+   // to odcinek w ca≈Ço≈õci mie≈õci siƒô w okienku
    // - zaznacz go na zielono
 //   else
    if ((rcode1 or rcode2) = 0) then

--- a/lib/graph_c4p.inc
+++ b/lib/graph_c4p.inc
@@ -25,7 +25,7 @@ begin
 
 ;$FFED
 ;SCREEN. Fetch number of screen rows and columns.
-;Input: –
+;Input: â€“
 ;Output: X = Number of columns (40); Y = Number of rows (25).
 ;Used registers: X, Y.
 ;Real address: $E505.

--- a/lib/misc.pas
+++ b/lib/misc.pas
@@ -540,28 +540,28 @@ copy
 	lda ext_b
 	pha
 
-	ldx #$0f	;zapamiêtanie bajtów ext (z 16 bloków po 64k)
+	ldx #$0f	;zapamiÄ™tanie bajtÃ³w ext (z 16 blokÃ³w po 64k)
 _p0	jsr setpb
 	lda ext_b
 	sta bsav,x
 	dex
 	bpl _p0
 
-	ldx #$0f	;wyzerowanie ich (w oddzielnej pêtli, bo nie wiadomo
-_p1	jsr setpb	;które kombinacje bitów PORTB wybieraj¹ te same banki)
+	ldx #$0f	;wyzerowanie ich (w oddzielnej pÄ™tli, bo nie wiadomo
+_p1	jsr setpb	;ktÃ³re kombinacje bitÃ³w PORTB wybierajÄ… te same banki)
 	lda #$00
 	sta ext_b
 	dex
 	bpl _p1
 
-	stx portb	;eliminacja pamiêci podstawowej
+	stx portb	;eliminacja pamiÄ™ci podstawowej
 	stx ext_b
-	stx $00		;niezbêdne dla niektórych rozszerzeñ do 256k
+	stx $00		;niezbÄ™dne dla niektÃ³rych rozszerzeÅ„ do 256k
 
-	ldy #$00	;pêtla zliczaj¹ca bloki 64k
+	ldy #$00	;pÄ™tla zliczajÄ…ca bloki 64k
 	ldx #$0f
 _p2	jsr setpb
-	lda ext_b	;jeœli ext_b jest ró¿ne od zera, blok 64k ju¿ zliczony
+	lda ext_b	;jeÅ›li ext_b jest rÃ³Å¼ne od zera, blok 64k juÅ¼ zliczony
 	bne _n2
 
 	dec ext_b	;w przeciwnym wypadku zaznacz jako zliczony
@@ -569,12 +569,12 @@ _p2	jsr setpb
 	lda ext_b	;sprawdz, czy sie zaznaczyl; jesli nie -> cos nie tak ze sprzetem
 	bpl _n2
 
-	lda portb	;wpisz wartoœæ PORTB do tablicy dla banku 0
+	lda portb	;wpisz wartoÅ›Ä‡ PORTB do tablicy dla banku 0
 
 	and #$fe
 
 	sta adr.banks,y
-	eor #%00000100	;uzupe³nij wartoœci dla banków 1, 2, 3
+	eor #%00000100	;uzupeÅ‚nij wartoÅ›ci dla bankÃ³w 1, 2, 3
 	sta adr.banks+1,y
 	eor #%00001100
 	sta adr.banks+2,y
@@ -588,7 +588,7 @@ _p2	jsr setpb
 _n2	dex
 	bpl _p2
 
-	ldx #$0f	;przywrócenie zawartoœci ext
+	ldx #$0f	;przywrÃ³cenie zawartoÅ›ci ext
 _p3	jsr setpb
 	lda bsav,x
 	sta ext_b
@@ -608,13 +608,13 @@ _p3	jsr setpb
 	rts
 
 ; podprogramy
-setpb	txa		;zmiana kolejnoœci bitów: %0000dcba -> %cba000d0
+setpb	txa		;zmiana kolejnoÅ›ci bitÃ³w: %0000dcba -> %cba000d0
 	lsr
 	ror
 	ror
 	ror
 	adc #$01	;ustawienie bitu nr 1 w zaleznosci od stanu C
-	ora #$01	;ustawienie bitu steruj¹cego OS ROM na wartosc domyslna
+	ora #$01	;ustawienie bitu sterujÄ…cego OS ROM na wartosc domyslna
 	sta portb
 	rts
 
@@ -674,7 +674,7 @@ _p0	jsr setb
 	sta ext_b
 
 	lda #$ff
-	sta portb	;eliminacja pamiêci podstawowej
+	sta portb	;eliminacja pamiÄ™ci podstawowej
 	sta ext_b
 
 _p2	jsr setb

--- a/lib/shrinkler.pas
+++ b/lib/shrinkler.pas
@@ -210,7 +210,7 @@ dzx0s_elias_loop
 		asl   @
 		bne   dzx0s_elias_skip
 		jsr   GET_BYTE
-		sec   ; mo¿na usun¹æ jeœli dekompresja z pamiêci a nie pliku
+		sec   ; moÅ¼na usunÄ…Ä‡ jeÅ›li dekompresja z pamiÄ™ci a nie pliku
 		rol   @
 dzx0s_elias_skip
 		bcc   dzx0s_elias_backtrack
@@ -377,7 +377,7 @@ dzx0s_elias_loop
 		asl   @
 		bne   dzx0s_elias_skip
 		jsr   GET_BYTE
-		sec   ; mo¿na usun¹æ jeœli dekompresja z pamiêci a nie pliku
+		sec   ; moÅ¼na usunÄ…Ä‡ jeÅ›li dekompresja z pamiÄ™ci a nie pliku
 		rol   @
 dzx0s_elias_skip
 		bcc   dzx0s_elias_backtrack

--- a/lib/vbxe.pas
+++ b/lib/vbxe.pas
@@ -1,7 +1,7 @@
 unit vbxe;
 (*
  @type: unit
- @author: Tomasz Biela (Tebe), Daniel KoümiÒski
+ @author: Tomasz Biela (Tebe), Daniel Ko≈∫mi≈Ñski
  @name: Video Board XE unit
 
  @version: 1.1

--- a/lib/zx0.pas
+++ b/lib/zx0.pas
@@ -210,7 +210,7 @@ dzx0s_elias_loop
 		asl   @
 		bne   dzx0s_elias_skip
 		jsr   GET_BYTE
-		sec   ; mo¿na usun¹æ jeœli dekompresja z pamiêci a nie pliku
+		sec   ; moÅ¼na usunÄ…Ä‡ jeÅ›li dekompresja z pamiÄ™ci a nie pliku
 		rol   @
 dzx0s_elias_skip
 		bcc   dzx0s_elias_backtrack
@@ -381,7 +381,7 @@ dzx0s_elias_loop
 		asl   @
 		bne   dzx0s_elias_skip
 		jsr   GET_BYTE
-		sec   ; mo¿na usun¹æ jeœli dekompresja z pamiêci a nie pliku
+		sec   ; moÅ¼na usunÄ…Ä‡ jeÅ›li dekompresja z pamiÄ™ci a nie pliku
 		rol   @
 dzx0s_elias_skip
 		bcc   dzx0s_elias_backtrack

--- a/lib/zx5.pas
+++ b/lib/zx5.pas
@@ -220,7 +220,7 @@ dzx5s_other_offset
 		asl   @
 		bne   dzx5s_other_offset_skip
 		jsr   _GET_BYTE
-		sec	; mo縩a usun规 je渓i dekompresja z pami阠i a nie pliku
+		sec	; mo偶na usun膮膰 je艣li dekompresja z pami臋ci a nie pliku
 		rol   @
 dzx5s_other_offset_skip
 		bcc   dzx5s_prev_offset
@@ -289,7 +289,7 @@ dzx5s_elias_loop
 		asl   @
 		bne   dzx5s_elias_skip
 		jsr   _GET_BYTE
-		sec	; mo縩a usun规 je渓i dekompresja z pami阠i a nie pliku
+		sec	; mo偶na usun膮膰 je艣li dekompresja z pami臋ci a nie pliku
 		rol   @
 dzx5s_elias_skip
 		bcc   dzx5s_elias_backtrack
@@ -421,7 +421,7 @@ dzx5s_other_offset
 		asl   @
 		bne   dzx5s_other_offset_skip
 		jsr   _GET_BYTE
-		sec	; mo縩a usun规 je渓i dekompresja z pami阠i a nie pliku
+		sec	; mo偶na usun膮膰 je艣li dekompresja z pami臋ci a nie pliku
 		rol   @
 dzx5s_other_offset_skip
 		bcc   dzx5s_prev_offset
@@ -490,7 +490,7 @@ dzx5s_elias_loop
 		asl   @
 		bne   dzx5s_elias_skip
 		jsr   _GET_BYTE
-		sec	; mo縩a usun规 je渓i dekompresja z pami阠i a nie pliku
+		sec	; mo偶na usun膮膰 je艣li dekompresja z pami臋ci a nie pliku
 		rol   @
 dzx5s_elias_skip
 		bcc   dzx5s_elias_backtrack

--- a/samples/a8/crt_console/palindrom.pas
+++ b/samples/a8/crt_console/palindrom.pas
@@ -2,19 +2,19 @@ program palindrom;
 uses crt;
 
 const
-  vdec = 2;                // sta³a liczbowa w kodzie dziesiêtnym
-  vhex = $ff;              // sta³a liczbowa w kodzie szesnastkowym
-  vbin = %10110001;        // sta³a liczbowa w kodzie binarnym
-  e = 2.7182818;           // sta³a zmiennoprzecinkowa
+  vdec = 2;                // staÅ‚a liczbowa w kodzie dziesiÄ™tnym
+  vhex = $ff;              // staÅ‚a liczbowa w kodzie szesnastkowym
+  vbin = %10110001;        // staÅ‚a liczbowa w kodzie binarnym
+  e = 2.7182818;           // staÅ‚a zmiennoprzecinkowa
 
-  d = (2 * pi * 12.4);      // sta³e z u¿yciem operatorów
-  ls = SizeOf(cardinal);   // sta³a zawieraj¹ca rozmiar zmiennej typu cardinal
-  x: word = 5;             // wymuszenie typu sta³ej
-  a = ord('A');            // sta³a zawieraj¹ca kod ATASCII znaku A
-  b = '4';                 // sta³a znakowa
-  c = chr(65);             // sta³a zawieraj¹ca znak o kodzie 65
+  d = (2 * pi * 12.4);      // staÅ‚e z uÅ¼yciem operatorÃ³w
+  ls = SizeOf(cardinal);   // staÅ‚a zawierajÄ…ca rozmiar zmiennej typu cardinal
+  x: word = 5;             // wymuszenie typu staÅ‚ej
+  a = ord('A');            // staÅ‚a zawierajÄ…ca kod ATASCII znaku A
+  b = '4';                 // staÅ‚a znakowa
+  c = chr(65);             // staÅ‚a zawierajÄ…ca znak o kodzie 65
 
-  ts = 'atari';             // ³añcuch znaków
+  ts = 'atari';             // Å‚aÅ„cuch znakÃ³w
   t: array [0..3] of byte = (16, 24, 48, 64);  // tablica
 
 var

--- a/samples/a8/games/MadKingdom/assets/cards.asm
+++ b/samples/a8/games/MadKingdom/assets/cards.asm
@@ -317,9 +317,9 @@ card_give_gold_bishop
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_bishop) ; actor pointer
 	dta a(txt_desc_give_gold) ; common description / question
-	; Najjaśniejszy Panie, potrzeba nam złota
+	; NajjaĹ›niejszy Panie, potrzeba nam zĹ‚ota
 	dta a(txt_quote_give_gold_bishop) ; actor sentence
-	; Katedra popada w ruinę, wspomóż...
+	; Katedra popada w ruinÄ™, wspomĂłĹĽ...
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -341,9 +341,9 @@ card_give_gold_general
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_general) ; actor pointer
 	dta a(txt_desc_give_gold) ; common description / question
-	; Najjaśniejszy Panie, potrzeba nam złota
+	; NajjaĹ›niejszy Panie, potrzeba nam zĹ‚ota
 	dta a(txt_quote_give_gold_general) ; actor sentence
-	; Musimy doposażyć nowych rekrutów.
+	; Musimy doposaĹĽyÄ‡ nowych rekrutĂłw.
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_no_chance) ; No response
 
@@ -364,9 +364,9 @@ card_give_gold_medic
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_medic) ; actor pointer
 	dta a(txt_desc_give_gold) ; common description / question
-	; Najjaśniejszy Panie, potrzeba nam złota
+	; NajjaĹ›niejszy Panie, potrzeba nam zĹ‚ota
 	dta a(txt_quote_give_gold_medic) ; actor sentence
-	; w szpitalach brak medykamentów.
+	; w szpitalach brak medykamentĂłw.
 	dta a(txt_yes_yes) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -387,9 +387,9 @@ card_crime_rises_executioner
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_executioner) ; actor pointer
 	dta a(txt_desc_crime_rises) ; common description / question
-	; Przestępczość rośnie Jaśniepanie
+	; PrzestÄ™pczoĹ›Ä‡ roĹ›nie JaĹ›niepanie
 	dta a(txt_quote_crime_rises_executioner) ; actor sentence
-	; może jakieś publiczne wieszanko?
+	; moĹĽe jakieĹ› publiczne wieszanko?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_no_way) ; No response
 
@@ -410,9 +410,9 @@ card_crime_rises_stargazer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_stargazer) ; actor pointer
 	dta a(txt_desc_crime_rises) ; common description / question
-	; Przestępczość rośnie Jaśniepanie
+	; PrzestÄ™pczoĹ›Ä‡ roĹ›nie JaĹ›niepanie
 	dta a(txt_quote_crime_rises_stargazer) ; actor sentence
-	; gwiazdy mówią igrzysk!
+	; gwiazdy mĂłwiÄ… igrzysk!
 	dta a(txt_yes_let_it_be) ; yes response
 	dta a(txt_no_no_way) ; No response
 
@@ -434,9 +434,9 @@ card_crime_rises_treasurer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_treasurer) ; actor pointer
 	dta a(txt_desc_crime_rises) ; common description / question
-	; Przestępczość rośnie Jaśniepanie
+	; PrzestÄ™pczoĹ›Ä‡ roĹ›nie JaĹ›niepanie
 	dta a(txt_quote_crime_rises_treasurer) ; actor sentence
-	; Zbudujmy więcej więzień!
+	; Zbudujmy wiÄ™cej wiÄ™zieĹ„!
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_no_chance) ; No response
 
@@ -460,9 +460,9 @@ card_luck_check_jester
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_jester) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_jester) ; actor sentence
-	; Może zagramy partyjkę Wista?
+	; MoĹĽe zagramy partyjkÄ™ Wista?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -480,9 +480,9 @@ card_enemy_approach_knight
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_knight) ; actor pointer
 	dta a(txt_desc_enemy_approach) ; common description / question
-	; Wrogowie stoją u bram miasta!
+	; Wrogowie stojÄ… u bram miasta!
 	dta a(txt_quote_enemy_approach_knight) ; actor sentence
-	; Pozwól Panie, że wzmocnimy straże.
+	; PozwĂłl Panie, ĹĽe wzmocnimy straĹĽe.
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -506,9 +506,9 @@ card_give_gold_peasant
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_peasant) ; actor pointer
 	dta a(txt_desc_give_gold) ; common description / question
-	; Najjaśniejszy Panie, potrzeba nam złota
+	; NajjaĹ›niejszy Panie, potrzeba nam zĹ‚ota
 	dta a(txt_quote_give_gold_peasant) ; actor sentence
-	; Plony słabe, susza, żyć nie ma za co...
+	; Plony sĹ‚abe, susza, ĹĽyÄ‡ nie ma za co...
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_go_away) ; No response
 
@@ -530,9 +530,9 @@ card_betrayal_jester
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_jester) ; actor pointer
 	dta a(txt_desc_betrayal) ; common description / question
-	; Mam wrażenie Panie, że ktoś spiskuje
+	; Mam wraĹĽenie Panie, ĹĽe ktoĹ› spiskuje
 	dta a(txt_quote_betrayal_jester) ; actor sentence
-	; powinniśmy ograniczyć wpływy kościoła.
+	; powinniĹ›my ograniczyÄ‡ wpĹ‚ywy koĹ›cioĹ‚a.
 	dta a(txt_yes_yes) ; yes response
 	dta a(txt_no_no_way) ; No response
 
@@ -554,9 +554,9 @@ card_luck_check_bishop
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_bishop) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_bishop) ; actor sentence
-	; Hojna ofiara pomoże uzyskać łaski...
+	; Hojna ofiara pomoĹĽe uzyskaÄ‡ Ĺ‚aski...
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_no_chance) ; No response
 
@@ -579,9 +579,9 @@ card_betrayal_stargazer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_stargazer) ; actor pointer
 	dta a(txt_desc_betrayal) ; common description / question
-	; Mam wrażenie Panie, że ktoś spiskuje
+	; Mam wraĹĽenie Panie, ĹĽe ktoĹ› spiskuje
 	dta a(txt_quote_betrayal_stargazer) ; actor sentence
-	; Gwiazdy mówią, aby inwestować w armię.
+	; Gwiazdy mĂłwiÄ…, aby inwestowaÄ‡ w armiÄ™.
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -601,9 +601,9 @@ card_luck_check_stargazer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_stargazer) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_stargazer) ; actor sentence
-	; Czy postawić najjaśniejszemu horoskop?
+	; Czy postawiÄ‡ najjaĹ›niejszemu horoskop?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -626,7 +626,7 @@ card_luck_check_treasurer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_treasurer) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_treasurer) ; actor sentence
 	; Zainwestujmy w drogocenne kruszce!
 	dta a(txt_yes_yes) ; yes response
@@ -648,7 +648,7 @@ card_give_gold_knight
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_knight) ; actor pointer
 	dta a(txt_desc_give_gold) ; common description / question
-	; Najjaśniejszy Panie, potrzeba nam złota
+	; NajjaĹ›niejszy Panie, potrzeba nam zĹ‚ota
 	dta a(txt_quote_give_gold_knight) ; actor sentence
 	; Zorganizujmy turniej rycerski!
 	dta a(txt_yes_generosity) ; yes response
@@ -674,7 +674,7 @@ card_luck_check_medic
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_medic) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_medic) ; actor sentence
 	; Mam dla Pana nowy lek z dalekiego kraju
 	dta a(txt_yes_yes) ; yes response
@@ -695,9 +695,9 @@ card_enemy_approach_general
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_general) ; actor pointer
 	dta a(txt_desc_enemy_approach) ; common description / question
-	; Wrogowie stoją u bram miasta!
+	; Wrogowie stojÄ… u bram miasta!
 	dta a(txt_quote_enemy_approach_general) ; actor sentence
-	; Panie, ogłośmy powszechną mobilizację!
+	; Panie, ogĹ‚oĹ›my powszechnÄ… mobilizacjÄ™!
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -720,9 +720,9 @@ card_dragon_peasant
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_peasant) ; actor pointer
 	dta a(txt_desc_dragon) ; common description / question
-	; W królestwie grasuje okrutny smok!
+	; W krĂłlestwie grasuje okrutny smok!
 	dta a(txt_quote_dragon_peasant) ; actor sentence
-	; Panie wyślij armię, chroń nasz dobytek.
+	; Panie wyĹ›lij armiÄ™, chroĹ„ nasz dobytek.
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_go_away) ; No response
 
@@ -744,9 +744,9 @@ card_betrayal_executioner
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_executioner) ; actor pointer
 	dta a(txt_desc_betrayal) ; common description / question
-	; Mam wrażenie Panie, że ktoś spiskuje
+	; Mam wraĹĽenie Panie, ĹĽe ktoĹ› spiskuje
 	dta a(txt_quote_betrayal_executioner) ; actor sentence
-	; Może zetniemy na pokaz kilku zdrajców?
+	; MoĹĽe zetniemy na pokaz kilku zdrajcĂłw?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -768,9 +768,9 @@ card_betrayal_bishop
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_bishop) ; actor pointer
 	dta a(txt_desc_betrayal) ; common description / question
-	; Mam wrażenie Panie, że ktoś spiskuje
+	; Mam wraĹĽenie Panie, ĹĽe ktoĹ› spiskuje
 	dta a(txt_quote_betrayal_bishop) ; actor sentence
-	; Wypędźmy wrogów kościoła z kraju.
+	; WypÄ™dĹşmy wrogĂłw koĹ›cioĹ‚a z kraju.
 	dta a(txt_yes_let_it_be) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -794,9 +794,9 @@ card_luck_check_executioner
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_executioner) ; actor pointer
 	dta a(txt_desc_luck_check) ; common description / question
-	; Zobaczmy czy sprzyja władcy szczęście
+	; Zobaczmy czy sprzyja wĹ‚adcy szczÄ™Ĺ›cie
 	dta a(txt_quote_luck_check_executioner) ; actor sentence
-	; Zetnijmy kogoś na chybił trafił!
+	; Zetnijmy kogoĹ› na chybiĹ‚ trafiĹ‚!
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -817,9 +817,9 @@ card_crime_rises_general
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_general) ; actor pointer
 	dta a(txt_desc_crime_rises) ; common description / question
-	; Przestępczość rośnie Jaśniepanie
+	; PrzestÄ™pczoĹ›Ä‡ roĹ›nie JaĹ›niepanie
 	dta a(txt_quote_crime_rises_general) ; actor sentence
-	; Zwiększmy patrole! Więcej wojska!
+	; ZwiÄ™kszmy patrole! WiÄ™cej wojska!
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_no_way) ; No response
 
@@ -844,9 +844,9 @@ card_dragon_jester
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_jester) ; actor pointer
 	dta a(txt_desc_dragon) ; common description / question
-	; W królestwie grasuje okrutny smok!
+	; W krĂłlestwie grasuje okrutny smok!
 	dta a(txt_quote_dragon_jester) ; actor sentence
-	; Najlepszy moment by pozbyć się dziewic!
+	; Najlepszy moment by pozbyÄ‡ siÄ™ dziewic!
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -870,9 +870,9 @@ card_dragon_knight
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_knight) ; actor pointer
 	dta a(txt_desc_dragon) ; common description / question
-	; W królestwie grasuje okrutny smok!
+	; W krĂłlestwie grasuje okrutny smok!
 	dta a(txt_quote_dragon_knight) ; actor sentence
-	; Pozwól Panie, że spróbuje ubić gada.
+	; PozwĂłl Panie, ĹĽe sprĂłbuje ubiÄ‡ gada.
 	dta a(txt_yes_ofc) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -896,9 +896,9 @@ card_disease_medic
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_medic) ; actor pointer
 	dta a(txt_desc_disease) ; common description / question
-	; Wybuchła zaraza, czarna śmierć w kraju
+	; WybuchĹ‚a zaraza, czarna Ĺ›mierÄ‡ w kraju
 	dta a(txt_quote_disease_medic) ; actor sentence
-	; Potrzeba pieniędzy na nowe szpitale.
+	; Potrzeba pieniÄ™dzy na nowe szpitale.
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_no_chance) ; No response
 
@@ -922,9 +922,9 @@ card_disease_peasant
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_peasant) ; actor pointer
 	dta a(txt_desc_disease) ; common description / question
-	; Wybuchła zaraza, czarna śmierć w kraju
+	; WybuchĹ‚a zaraza, czarna Ĺ›mierÄ‡ w kraju
 	dta a(txt_quote_disease_peasant) ; actor sentence
-	; Chcemy schronić się w murach miasta.
+	; Chcemy schroniÄ‡ siÄ™ w murach miasta.
 	dta a(txt_yes_let_it_be) ; yes response
 	dta a(txt_no_go_away) ; No response
 
@@ -949,9 +949,9 @@ card_betrayal_treasurer
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_treasurer) ; actor pointer
 	dta a(txt_desc_betrayal) ; common description / question
-	; Mam wrażenie Panie, że ktoś spiskuje
+	; Mam wraĹĽenie Panie, ĹĽe ktoĹ› spiskuje
 	dta a(txt_quote_betrayal_treasurer) ; actor sentence
-	; A może czas zbudować sieć wywiadowczą?
+	; A moĹĽe czas zbudowaÄ‡ sieÄ‡ wywiadowczÄ…?
 	dta a(txt_yes_yes) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -974,9 +974,9 @@ card_neardeath_death
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_death) ; actor pointer
 	dta a(txt_desc_neardeath) ; common description / question
-	; Podupadłeś na zdrowiu jaśniepanie.
+	; PodupadĹ‚eĹ› na zdrowiu jaĹ›niepanie.
 	dta a(txt_quote_neardeath_death) ; actor sentence
-	; Możesz poświęcić życie kilku poddanych.
+	; MoĹĽesz poĹ›wiÄ™ciÄ‡ ĹĽycie kilku poddanych.
 	dta a(txt_yes_yes) ; yes response
 	dta a(txt_no_go_away) ; No response
 
@@ -1000,9 +1000,9 @@ card_trade_devil
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_devil) ; actor pointer
 	dta a(txt_desc_trade) ; common description / question
-	; Witam najjaśniejszego, pohandlujemy?
+	; Witam najjaĹ›niejszego, pohandlujemy?
 	dta a(txt_quote_trade_devil) ; actor sentence
-	; Za Twą dusze, bogactwa oddam wielkie.
+	; Za TwÄ… dusze, bogactwa oddam wielkie.
 	dta a(txt_yes_let_it_be) ; yes response
 	dta a(txt_no_no_way) ; No response
 
@@ -1026,9 +1026,9 @@ card_welcome_angel
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_angel) ; actor pointer
 	dta a(txt_desc_welcome) ; common description / question
-	; Witam sprawiedliwego jaśniepana.
+	; Witam sprawiedliwego jaĹ›niepana.
 	dta a(txt_quote_welcome_angel) ; actor sentence
-	; Oferuję swe łaski za hojną ofiarę.
+	; OferujÄ™ swe Ĺ‚aski za hojnÄ… ofiarÄ™.
 	dta a(txt_yes_generosity) ; yes response
 	dta a(txt_no_rather_no) ; No response
 
@@ -1055,9 +1055,9 @@ card_bigarmy_general
 	dta 0 ; type   0:resource_card 1:gamble_card
 	dta a(actor_general) ; actor pointer
 	dta a(txt_desc_bigarmy) ; common description / question
-	; Nasza armia jest już potężna,
+	; Nasza armia jest juĹĽ potÄ™ĹĽna,
 	dta a(txt_quote_bigarmy_general) ; actor sentence
-	; może złupimy sąsiedni kraj?
+	; moĹĽe zĹ‚upimy sÄ…siedni kraj?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_overstatement) ; No response
 
@@ -1085,7 +1085,7 @@ card_unhappy_bishop
 	dta a(txt_desc_unhappy) ; common description / question
 	; Lud niespokojny ostatnimi czasy,
 	dta a(txt_quote_unhappy_bishop) ; actor sentence
-	; może trzeba urządzić wielką procesję?
+	; moĹĽe trzeba urzÄ…dziÄ‡ wielkÄ… procesjÄ™?
 	dta a(txt_yes_great_idea) ; yes response
 	dta a(txt_no_go_away) ; No response
 

--- a/samples/a8/graph_vbxe/blit.pas
+++ b/samples/a8/graph_vbxe/blit.pas
@@ -39,7 +39,7 @@ const
 	$99, $96, $93, $90, $8c, $89, $86, $83
 	);
 
-	bonus = VBXE_OVRADR+320*256;				// adres bitmapy w pamiêci VBXE, ladowana przez RESOURCE $R
+	bonus = VBXE_OVRADR+320*256;				// adres bitmapy w pamiÄ™ci VBXE, ladowana przez RESOURCE $R
 
 	src0 = bonus + 0;
 	src1 = bonus + 16;

--- a/samples/a8/graph_vbxe/bmp2.pas
+++ b/samples/a8/graph_vbxe/bmp2.pas
@@ -1,5 +1,5 @@
 
-// przyk≥ad uzycia GetXDL, SetXDL
+// przyk≈Çad uzycia GetXDL, SetXDL
 
 {$r amiga.rc}
 

--- a/samples/a8/sound/mod/modplay2.pas
+++ b/samples/a8/sound/mod/modplay2.pas
@@ -1,7 +1,7 @@
 
 // 6502 MOD Player 2.3 (VBL, IRQ) 8 kHz (POKEY 1.7 MHz)
 // pattern limit = 37
-// sample length limit = 16384 bytes , ladowane do koñca banku ($7fff)
+// sample length limit = 16384 bytes , ladowane do koÅ„ca banku ($7fff)
 
 // volume $de00 - $feff
 

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -37,7 +37,7 @@ Contributors:
 	- unit GRAPHICS: TextOut
 	- unit EFAST
 
-+ Daniel KoümiÒski :
++ Daniel Ko≈∫mi≈Ñski :
 	- unit STRINGUTILS
 	- unit CIO
 
@@ -58,7 +58,7 @@ Contributors:
 	- unit LZ4: unLZ4
 	- unit aPLib: unAPL
 
-+ Marcin Øukowski :
++ Marcin ≈ªukowski :
 	- unit FASTGRAPH: fLine
 
 + Michael Jaskula :
@@ -84,7 +84,7 @@ Contributors:
 	- 8x8 => 16 multiplication routine (base\common\byte.asm)
 	- 16x16 => 32 multiplication routine (base\common\word.asm)
 
-+ Wojciech BociaÒski :
++ Wojciech Bocia≈Ñski :
 	- library BLIBS: B_CRT, B_DL, B_PMG, B_SYSTEM, B_UTILS, XBIOS
 	- MADSTRAP
 	- PASDOC
@@ -93,7 +93,7 @@ Contributors:
 # rejestr X (=$FF) uzywany jest do przekazywania parametrow przez programowy stos :STACKORIGIN
 # stos programowy sluzy tez do tymczasowego przechowywania wyrazen, wynikow operacji itp.
 
-# typ REAL Fixed-Point Q16.16 przekracza 32 bity dla MUL i DIV, czÍsty OVERFLOW
+# typ REAL Fixed-Point Q16.16 przekracza 32 bity dla MUL i DIV, czƒôsty OVERFLOW
 
 # uzywaj asm65('') zamiast #13#10, POS bedzie wlasciwie zwracalo indeks
 
@@ -107,7 +107,7 @@ Contributors:
 
 # wartosc dla typu POINTER zwiekszana jest o CODEORIGIN
 
-# :BP  tylko przy adresowaniu 1-go bajtu, :BP = $00 !!!, zmienia siÍ tylko :BP+1
+# :BP  tylko przy adresowaniu 1-go bajtu, :BP = $00 !!!, zmienia siƒô tylko :BP+1
 # :BP2 przy adresowaniu wiecej niz 1-go bajtu (WORD, CARDINAL itd.)
 
 # indeks dla jednowymiarowej tablicy [0..x] = a * DataSize[AllocElementType]
@@ -379,7 +379,7 @@ const
   MAXIDENTS		= 16384;
   MAXBLOCKS		= 16384;	// maksymalna liczba blokow
   MAXPARAMS		= 8;		// maksymalna liczba parametrow dla PROC, FUNC
-  MAXVARS		= 256;		// maksymalna liczba parametrÛw dla VAR
+  MAXVARS		= 256;		// maksymalna liczba parametr√≥w dla VAR
   MAXUNITS		= 512;
   MAXDEFINES		= 256;		// maksymalna liczba $DEFINE
   MAXALLOWEDUNITS	= 256;
@@ -34936,28 +34936,28 @@ end;
 (*
 procedure GenerateInterrupt(InterruptNumber: Byte);
 
- DLI     5  ($200)   Wektor przerwaÒ NMI listy displejowej
+ DLI     5  ($200)   Wektor przerwa≈Ñ NMI listy displejowej
  VBI     6  ($222)   Wektor NMI natychmiastowego VBI
- VBL     7  ($224)   Wektor NMI opÛünionego VBI
+ VBL     7  ($224)   Wektor NMI op√≥≈∫nionego VBI
  RESET
  IRQ
  BRK
 
-VDSLST $0200 $E7B3 Wektor przerwaÒ NMI listy displejowej
+VDSLST $0200 $E7B3 Wektor przerwa≈Ñ NMI listy displejowej
 VPRCED $0202 $E7B3 Wektor IRQ procedury pryferyjnej
-VINTER $0204 $E7B3 Wektor IRQ urzπdzeÒ peryferyjnych
+VINTER $0204 $E7B3 Wektor IRQ urzƒÖdze≈Ñ peryferyjnych
 VBREAK $0206 $E7B3 Wektor IRQ programowej instrukcji BRK
 VKEYBD $0208 $EFBE Wektor IRQ klawiatury
-VSERIN $020A $EB11 Wektor IRQ gotowoúci wejúcia szeregowego
-VSEROR $020C $EA90 Wektor IRQ gotowoúci wyjúcia szeregowego
-VSEROC $020E $EAD1 Wektor IRQ zakoÒczenia przesy≥ania szereg.
-VTIMR1 $0210 $E7B3 Wektor IRQ licznika 1 uk≥adu POKEY
-VTIMR2 $0212 $E7B3 Wektor IRQ licznika 2 uk≥adu POKEY
-VTIMR4 $0214 $E7B3 Wektor IRQ licznika 4 uk≥adu POKEY
+VSERIN $020A $EB11 Wektor IRQ gotowo≈õci wej≈õcia szeregowego
+VSEROR $020C $EA90 Wektor IRQ gotowo≈õci wyj≈õcia szeregowego
+VSEROC $020E $EAD1 Wektor IRQ zako≈Ñczenia przesy≈Çania szereg.
+VTIMR1 $0210 $E7B3 Wektor IRQ licznika 1 uk≈Çadu POKEY
+VTIMR2 $0212 $E7B3 Wektor IRQ licznika 2 uk≈Çadu POKEY
+VTIMR4 $0214 $E7B3 Wektor IRQ licznika 4 uk≈Çadu POKEY
 
-VIMIRQ $0216 $E6F6 Wektor sterownika przerwaÒ IRQ
+VIMIRQ $0216 $E6F6 Wektor sterownika przerwa≈Ñ IRQ
 VVBLKI $0222 $E7D1 Wektor NMI natychmiastowego VBI
-VVBLKD $0224 $E93E Wektor NMI opÛünionego VBI
+VVBLKD $0224 $E93E Wektor NMI op√≥≈∫nionego VBI
 CDTMA1 $0226 $XXXX Adres JSR licznika systemowego 1
 CDTMA2 $0228 $XXXX Adres JSR licznika systemowego 2
 BRKKEY $0236 $E754 Wektor IRQ klawisza BREAK **
@@ -35006,8 +35006,8 @@ begin
 
 	if Ident[GetIdent(lab)].AllocElementType = RECORDTOK then begin
 
-	 asm65(#9'mwy '+lab+' :bp2');			// !!! koniecznie w ten sposÛb
-							// !!! kolejne optymalizacje podstawiπ pod :BP2 -> LAB
+	 asm65(#9'mwy '+lab+' :bp2');			// !!! koniecznie w ten spos√≥b
+							// !!! kolejne optymalizacje podstawiƒÖ pod :BP2 -> LAB
 	 asm65(#9'lda :bp2');
 	 asm65(#9'add #' + svar + '-DATAORIGIN');
 	 asm65(#9'sta :bp2');
@@ -45165,7 +45165,7 @@ WHILETOK:
   INCTOK, DECTOK:
 // dwie wersje
 // krotka i szybka, jesli mamy jeden parametr, np. INC(VAR), DEC(VAR)
-// d≥uga i wolna, jesli mamy tablice lub dwa parametry, np. INC(TMP[1]), DEC(VAR, VALUE+12)
+// d≈Çuga i wolna, jesli mamy tablice lub dwa parametry, np. INC(TMP[1]), DEC(VAR, VALUE+12)
     begin
 
       Value := 0;
@@ -48743,7 +48743,7 @@ while Tok[i].Kind in
 	 if Ident[ForwardIdentIndex].NumParams <> ParamIndex then
 	   Error(i, 'Wrong number of parameters specified for call to '+''''+Ident[ForwardIdentIndex].Name+'''');
 
-//	   function header îarg1î doesnít match forward : var name changes arg2 = arg3
+//	   function header ‚Äùarg1‚Äù doesn‚Äôt match forward : var name changes arg2 = arg3
 
 	 for ParamIndex := 1 to Ident[ForwardIdentIndex].NumParams do
 	  if ((Ident[ForwardIdentIndex].Param[ParamIndex].Name <> Param[ParamIndex].Name) or (Ident[ForwardIdentIndex].Param[ParamIndex].DataType <> Param[ParamIndex].DataType)) then


### PR DESCRIPTION
robotę zrobiono za pomocą:

```
#!/bin/bash

for i in `find . -name *.pas`
do
  recode WINDOWS-1250..UTF8 $i
done

for i in `find . -name *.inc`
do
  recode WINDOWS-1250..UTF8 $i
done
```

zmieniono

```
	modified:   blibs/xbios.pas
	modified:   lib/cio.pas
	modified:   lib/fastgraph.pas
	modified:   lib/fastmath.pas
	modified:   lib/graph.inc
	modified:   lib/graph_c4p.inc
	modified:   lib/misc.pas
	modified:   lib/shrinkler.pas
	modified:   lib/vbxe.pas
	modified:   lib/zx0.pas
	modified:   lib/zx5.pas
	modified:   samples/a8/crt_console/palindrom.pas
	modified:   samples/a8/graph_vbxe/blit.pas
	modified:   samples/a8/graph_vbxe/bmp2.pas
	modified:   samples/a8/sound/mod/modplay2.pas
	modified:   src/mp.pas
```

ręczna poprawka w `blibs/xbios.pas`