### PR TITLE
Fix Pos function.

### DIFF
--- a/lib/system.pas
+++ b/lib/system.pas
@@ -2036,7 +2036,7 @@ begin
     slen := Length(s);
     result := 0;
 
-    for i := 1 to slen - 1 do
+    for i := 1 to slen do
     begin
         if s[i] = c then
         begin


### PR DESCRIPTION
Funkcja Pos(c: char; s: string) ignoruje ostatni znak. Zakres pętli jest niepotrzebnie pomniejszony o 1.