### PR TITLE
Add flags restore after CIO operation

### DIFF
--- a/base/runtime/macros.asm
+++ b/base/runtime/macros.asm
@@ -20,9 +20,12 @@ m@call	.macro (os_proc)
 		inc portb
 
 		jsr %%os_proc
-
+		
+		php		; save flags on stack
+		
 		dec portb
 
+		plp		; restore flags from stack
 	.else
 
 		jsr %%os_proc


### PR DESCRIPTION
This modification is only for full compatibility with the original behavior of the CIOV procedure, where in the flag register after the operation, the N flag takes 1 when the operation returned an error; 0 - when it succeeded.

Unfortunately, the `dec PORTB` operation changes the state of the N flag, which has the effect of removing the result placed in this flag, after the CIO operation.