### PR TITLE
Update romoff.asm

### DIFF
--- a/base/atari/romoff.asm
+++ b/base/atari/romoff.asm
@@ -9,6 +9,12 @@
         lda #%11111110
         sta PORTB       ;$D301
 
+; Wprowadzona zmiana pozwala wyłączyć z poziomu kodu Pascala, kopiowanie czcionek z pamięci ROM do RAM przy wyłączonym ROMie
+; Proces ten (niefortunnie) powoduje nadpisanie danych w obszarze $E000..$E3FF, gdy w zasobach umieścimi dane, które
+; w ten obszar są wczytywane. Za pomocą definicji '{$DEFINE NOROMFONT}` można wyłączyć przerzut danych czcionek z ROM do RAMu,
+; co pozwala zachować, wczytywane zasoby.
+
+.ifndef MAIN.@DEFINES.NOROMFONT
 	ldx #3
 	ldy #0
 mv	inc portb
@@ -21,6 +27,7 @@ afnt1	sta $e000,y
 	inc afnt1+2
 	dex
 	bpl mv
+.endif
 
         ldx #<nmiint
         ldy #>nmiint


### PR DESCRIPTION
The introduced change allows you to disable, from the Pascal code level, the copying of font data from ROM to RAM when ROM is disabled. This process (unfortunate) overwrites the data in the area $E000..$E3FF, when we put in the resources that are loaded into this area. Using the definition of '{$DEFINE NOROMFONT}` you can disable the metastasis of font data from ROM to RAM, thus preserving, loaded resources.