### PR TITLE
Ability to disable IOCB#0 copy by 'DISABLEIOCBCOPY' directive

### DIFF
--- a/base/atari/cmdline.asm
+++ b/base/atari/cmdline.asm
@@ -70,26 +70,26 @@ no_sparta
 	sta	res
 
 ; ... or channel #0
-	lda	MAIN.IOCB@COPY+2	; command
+	lda	MAIN.SYSTEM.adr.IOCB_COPY+2	; command
 	cmp	#5			; read line
 	bne	_no_command_line
-	lda	MAIN.IOCB@COPY+3	; status
+	lda	MAIN.SYSTEM.adr.IOCB_COPY+3	; status
 	bmi	_no_command_line
 ; don't assume the line is EOL-terminated
 ; DOS II+/D overwrites the EOL with ".COM"
 ; that's why we rely on the length
-	lda	MAIN.IOCB@COPY+9	; length hi
+	lda	MAIN.SYSTEM.adr.IOCB_COPY+9	; length hi
 	bne	_no_command_line
-	ldx	MAIN.IOCB@COPY+8	; length lo
+	ldx	MAIN.SYSTEM.adr.IOCB_COPY+8	; length lo
 	beq	_no_command_line
 	inx:inx
 	stx	arg_len
 ; give access to three bytes before the input buffer
 ; in DOS II+/D the device prompt ("D1:") is there
-	lda	MAIN.IOCB@COPY+4
+	lda	MAIN.SYSTEM.adr.IOCB_COPY+4
 	sub	#3
 	sta	tmp
-	lda	MAIN.IOCB@COPY+5
+	lda	MAIN.SYSTEM.adr.IOCB_COPY+5
 	sbc	#0
 	sta	tmp+1
 

--- a/lib/system.pas
+++ b/lib/system.pas
@@ -2771,4 +2771,13 @@ begin
   Result:=longint(dword(dword(dword(AValue) shr (Shift and 31)) or (dword(longint(dword(0-dword(dword(AValue) shr 31)) and dword(longint(0-(ord((Shift and 31)<>0){ and 1}))))) shl (32-(Shift and 31)))));
 end;
 
+initialization
+{$ifdef atari}
+// Tworzenie kopii bloku IOCB#0 na potrzeby funkcji ParamStr i ParamCount
+asm
+  ldx #$0F	; DOS II+/D ParamStr
+  mva:rpl $340,x MAIN.SYSTEM.adr.IOCB_COPY,x-
+end;
+{$endif}
+
 end.

--- a/lib/system.pas
+++ b/lib/system.pas
@@ -2775,8 +2775,10 @@ initialization
 {$ifdef atari}
 // Tworzenie kopii bloku IOCB#0 na potrzeby funkcji ParamStr i ParamCount
 asm
+.IF .NOT .DEF MAIN.@DEFINES.DISABLEIOCBCOPY
   ldx #$0F	; DOS II+/D ParamStr
   mva:rpl $340,x MAIN.SYSTEM.adr.IOCB_COPY,x-
+.ENDIF
 end;
 {$endif}
 

--- a/lib/system_atari.inc
+++ b/lib/system_atari.inc
@@ -202,8 +202,9 @@ end;
 
 end;
 
-var
-	IOCB_COPY:array[0..15] of byte;		// kopia bloku IOCB#0.
+const
+	IOCB_COPY:array[0..15] of byte =		// kopia bloku IOCB#0
+(0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0);
 
 function ParamCount: byte; assembler;
 (*

--- a/lib/system_atari.inc
+++ b/lib/system_atari.inc
@@ -202,9 +202,11 @@ end;
 
 end;
 
+{$ifndef DISABLEIOCBCOPY}
 const
 	IOCB_COPY:array[0..15] of byte =		// kopia bloku IOCB#0
 (0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0);
+{$endif}
 
 function ParamCount: byte; assembler;
 (*

--- a/lib/system_atari.inc
+++ b/lib/system_atari.inc
@@ -202,6 +202,8 @@ end;
 
 end;
 
+var
+	IOCB_COPY:array[0..15] of byte;		// kopia bloku IOCB#0.
 
 function ParamCount: byte; assembler;
 (*

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -15187,13 +15187,14 @@ end;
 asm65;
 asm65(#9'rts');
 
-asm65separator;
+// Deklaracja kopii bloku IOCB#0 przeniesiona do biblioteki SYSTEM
+(* asm65separator;
 
 if target.id = 'a8' then begin
  asm65;
  asm65('IOCB@COPY'#9':16 brk');
 end;
-
+ *)
 asm65separator;
 
 asm65;

--- a/src/targets/generate_program_prolog.inc
+++ b/src/targets/generate_program_prolog.inc
@@ -305,11 +305,14 @@ if Pass = CODEGENERATIONPASS then begin
 
  if target.id = 'a8' then begin
 
-  asm65(#9'ldx #$0F','; DOS II+/D ParamStr');     // DOS II+/D ParamStr
-  asm65(#9'mva:rpl $340,x MAIN.IOCB@COPY,x-');
-  asm65;
+  asm65(#9'ldx #0');
+  // Inicjacja kopii bloku IOCB#0 przeniesiona do biblioteki SYSTEM
+  // w sekcji INITIALIZATION, obwarowana dyrektywą
+  // asm65(#9'ldx #$0F','; DOS II+/D ParamStr');     // DOS II+/D ParamStr
+  // asm65(#9'mva:rpl $340,x MAIN.IOCB@COPY,x-');
+  // asm65;
 
-  asm65(#9'inx','; X = 0');
+  // asm65(#9'inx','; X = 0');
   asm65(#9'stx bp','; BP = 0');
   asm65;
 


### PR DESCRIPTION
The change consists of discarding from the compiler code the initialisation of the `IOCB#0` block copy, which is used in the SYSTEM library functions: `paramCount()` and `paramStr()`.

After the change, the copy is only executed when the programmer declares the use of the above-mentioned functions. In addition, the memory allocated for the copy of the `IOCB#0` block is reserved in the static data area (STATICDATA) and not, as before, behind the program code.