### PR TITLE
Fix putchar subroutine for C64.

### DIFF
--- a/base/c64/putchar.asm
+++ b/base/c64/putchar.asm
@@ -5,33 +5,28 @@
 
   https://sta.c64.org/cbm64pet.html
   
-  Codes $00-$1F and $80-$9F are control codes. 
-  
+  For letters (codes 64-90 and 97-122), the code exchanges A-Z <-> a-z
+  (to convert ASCII -> PETSCII). It is required since Mad Pascal's source code
+  encoding is ASCII, and such strings must be converted to use with C64 Kernal
+  subroutines.
+  (Other way could be doing it on compiler level - write strings in proper
+  encoding in compiled code).
 */
 
 .proc	@putchar (.byte a) .reg
 
 chrout	= $ffd2			;kernel character output sub
 
-	tay
-
-	cmp #$20
-	bcc @+
-
-	tya
-	clc			; clear carry for add
-	adc #$FF-$9F		; make m = $FF
-	adc #$9F-$80+1		; carry set if in range n to m
-	jcc skp
-@
-	tya
-	jmp chrout
-
-skp	tya
-
 	cmp #64
-	scc
+	bcc putcharend
+	cmp #122
+	bcs putcharend
+	cmp #91
+	bcc putchareor
+	cmp #96
+	bcc putcharend
+putchareor
 	eor #%00100000
-
+putcharend
 	jmp chrout
 .endp


### PR DESCRIPTION
The characters from 91-96 were EORed (despite not being letters), what resulted in outputting invalid characters.

This convertion could be eventually moved to compiler code - so that it could convert strings to PETSCII when compiling for Commodores, so that the executable would contain proper encoding (the original putchar from kernal could be called in such case, so it would be a bit smaller/faster executable).
