### PR TITLE
Adapt remaining I/O to use IFile

### DIFF
--- a/src/Common.pas
+++ b/src/Common.pas
@@ -365,8 +365,8 @@ type
 
   );
 
-  TString = string [MAXSTRLENGTH];
-  TName   = string [MAXNAMELENGTH];
+  TString = string;
+  TName   = string;
 
   TDefinesParam = array [1..MAXPARAMS] of TString;
 
@@ -581,7 +581,7 @@ var
 
   FastMul: Integer = -1;
 
-  OutFile: TextFile;
+  OutFile: ITextFile;
 
   //AsmLabels: array of integer;
 
@@ -616,7 +616,7 @@ var
 
 {$IFDEF USEOPTFILE}
 
-  OptFile: TextFile;
+  OptFile: ITextFile;
 
 {$ENDIF}
 

--- a/src/Console.pas
+++ b/src/Console.pas
@@ -28,16 +28,23 @@ procedure NormVideo;
 
 implementation
 
+{$IFNDEF PAS2JS}
 uses Crt;
+{$ENDIF}
+
 
 procedure TextColor(color: Byte);
 begin
+ {$IFNDEF PAS2JS}
  Crt.TextColor(color);
+ {$ENDIF}
 end;
 
 procedure NormVideo();
 begin
+ {$IFNDEF PAS2JS}
  Crt.Normvideo;
+ {$ENDIF}
 end;
 
 

--- a/src/Diagnostic.pas
+++ b/src/Diagnostic.pas
@@ -19,68 +19,75 @@ uses SysUtils, Common, FileIO;
 
 procedure Diagnostics;
 var i, CharIndex, ChildIndex: Integer;
-    DiagFile: textfile;
+    DiagFile: ITextFile;
 begin
 
-  AssignFile(DiagFile, ChangeFileExt( UnitName[1].Name, '.txt') );
-  Rewrite(DiagFile);
+  DiagFile:=TFileSystem.CreateTextFile;
+  DiagFile.Assign(ChangeFileExt( UnitName[1].Name, '.txt') );
+  DiagFile.Rewrite;
 
-  WriteLn(DiagFile);
-  WriteLn(DiagFile, 'Token list: ');
-  WriteLn(DiagFile);
-  WriteLn(DiagFile, '#': 6, 'Unit': 30, 'Line': 6, 'Token': 30);
-  WriteLn(DiagFile);
+  DiagFile.WriteLn;
+  DiagFile.WriteLn('Token list: ');
+  DiagFile.WriteLn;
+  // DiagFile.WriteLn('#' : 6, 'Unit': 30, 'Line': 6, 'Token': 30);
+  DiagFile.Write('# ',6).Write( 'Unit',30).Write( 'Line',6).Write('Token',30).WriteLn;
+
+  DiagFile.WriteLn;
 
   for i := 1 to NumTok do
     begin
-    Write(DiagFile, i: 6, UnitName[Tok[i].UnitIndex].Name: 30, Tok[i].Line: 6, GetSpelling(i): 30);
+    // DiagFile.Write(i: 6, UnitName[Tok[i].UnitIndex].Name: 30, Tok[i].Line: 6, GetSpelling(i): 30);
+    DiagFile.Write(i,6).Write( UnitName[Tok[i].UnitIndex].Name, 30).Write(Tok[i].Line, 6).Write(GetSpelling(i), 30).WriteLn;
     if Tok[i].Kind = INTNUMBERTOK then
-      WriteLn(DiagFile, ' = ', Tok[i].Value)
+      DiagFile.WriteLn(' = ', IntToStr(Tok[i].Value))
     else if Tok[i].Kind = FRACNUMBERTOK then
-      WriteLn(DiagFile, ' = ', Tok[i].FracValue: 8: 4)
+//    DiagFile.WriteLn(' = ', Tok[i].FracValue: 8: 4)
+      DiagFile.WriteLn(' = ', FloatToStr(Tok[i].FracValue))
     else if Tok[i].Kind = IDENTTOK then
-      WriteLn(DiagFile, ' = ', Tok[i].Name)
+      DiagFile.WriteLn(' = ', Tok[i].Name)
     else if Tok[i].Kind = CHARLITERALTOK then
-      WriteLn(DiagFile, ' = ', Chr(Tok[i].Value))
+      DiagFile.WriteLn(' = ', Chr(Tok[i].Value))
     else if Tok[i].Kind = STRINGLITERALTOK then
       begin
-      Write(DiagFile, ' = ');
+      DiagFile.Write(' = ');
       for CharIndex := 1 to Tok[i].StrLength do
-	Write(DiagFile, StaticStringData[Tok[i].StrAddress - CODEORIGIN + (CharIndex - 1)]);
-      WriteLn(DiagFile);
+	DiagFile.Write( StaticStringData[Tok[i].StrAddress - CODEORIGIN + (CharIndex - 1)],-1);
+      DiagFile.WriteLn;
       end
     else
-      WriteLn(DiagFile);
+      DiagFile.WriteLn;
     end;// for
 
-  WriteLn(DiagFile);
-  WriteLn(DiagFile, 'Identifier list: ');
-  WriteLn(DiagFile);
-  WriteLn(DiagFile, '#': 6, 'Block': 6, 'Name': 30, 'Kind': 15, 'Type': 15, 'Items/Params': 15, 'Value/Addr': 15, 'Dead': 5);
-  WriteLn(DiagFile);
+  DiagFile.WriteLn;
+  DiagFile.WriteLn( 'Identifier list: ');
+  DiagFile.WriteLn;
+  DiagFile.Write( '#',6).Write('Block',6).Write( 'Name',30).Write('Kind',15).Write( 'Type', 15).Write( 'Items/Params', 15).Write( 'Value/Addr', 15).Write( 'Dead',5).WriteLn;
+  DiagFile.WriteLn;
 
   for i := 1 to NumIdent do
     begin
-    Write(DiagFile, i: 6, Ident[i].Block: 6, Ident[i].Name: 30, Spelling[Ident[i].Kind]: 15);
-    if Ident[i].DataType <> 0 then Write(DiagFile, Spelling[Ident[i].DataType]: 15) else Write(DiagFile, 'N/A': 15);
-    Write(DiagFile, Ident[i].NumAllocElements: 15, IntToHex(Ident[i].Value, 8): 15);
-    if (Ident[i].Kind in [PROCEDURETOK, FUNCTIONTOK, CONSTRUCTORTOK, DESTRUCTORTOK]) and not Ident[i].IsNotDead then WriteLn(DiagFile, 'Yes': 5) else WriteLn(DiagFile, '': 5);
+    DiagFile.Write( i, 6).Write( Ident[i].Block, 6).Write( Ident[i].Name, 30).Write( Spelling[Ident[i].Kind], 15);
+    if Ident[i].DataType <> 0 then DiagFile.Write( Spelling[Ident[i].DataType], 15) else DiagFile.Write( 'N/A', 15);
+    DiagFile.Write( Ident[i].NumAllocElements, 15).Write( IntToHex(Ident[i].Value, 8), 15);
+    if (Ident[i].Kind in [PROCEDURETOK, FUNCTIONTOK, CONSTRUCTORTOK, DESTRUCTORTOK]) and not Ident[i].IsNotDead
+    then DiagFile.Write( 'Yes', 5) else DiagFile.Write('', 5);
     end;
 
-  WriteLn(DiagFile);
-  WriteLn(DiagFile, 'Call graph: ');
-  WriteLn(DiagFile);
+  DiagFile.WriteLn;
+  DiagFile.WriteLn;
+  DiagFile.WriteLn( 'Call graph: ');
+  DiagFile.WriteLn;
 
   for i := 1 to NumBlocks do
     begin
-    Write(DiagFile, i: 6, '  ---> ');
+    DiagFile.Write( i, 6).Write('  ---> ');
     for ChildIndex := 1 to CallGraph[i].NumChildren do
-      Write(DiagFile, CallGraph[i].ChildBlock[ChildIndex]: 5);
-    WriteLn(DiagFile);
+      DiagFile.Write( CallGraph[i].ChildBlock[ChildIndex], 5);
+    DiagFile.WriteLn;
     end;
 
-  WriteLn(DiagFile);
-  CloseFile(DiagFile);
+  DiagFile.WriteLn;
+  DiagFile.Close;
 
 end;
 

--- a/src/Makefile.bat
+++ b/src/Makefile.bat
@@ -13,7 +13,7 @@ set PATH=%WUDSN_TOOLS_FOLDER%\PAS\FPC.jac;%WUDSN_TOOLS_FOLDER%\ASM\MADS\bin\wind
 set MP_FOLDER=%~dp0..
 set MP_SRC_FOLDER=%MP_FOLDER%\src
 
-rem set TEST_EXE=%MP_SRC_FOLDER%\Test-0.exe
+set TEST_EXE=%MP_SRC_FOLDER%\Test-0.exe
 set MP_EXE=%MP_SRC_FOLDER%\mp.exe
 
 set WUDSN_MP_EXE=%WUDSN_TOOLS_FOLDER%\PAS%\MP\bin\windows\mp.exe

--- a/src/Messages.pas
+++ b/src/Messages.pas
@@ -238,8 +238,8 @@ begin
 
  FreeTokens;
 
- CloseFile(OutFile);
- Erase(OutFile);
+ OutFile.Close();
+ OutFile.Erase();
 
  RaiseHaltException(2);
 
@@ -273,8 +273,11 @@ begin
 
  FreeTokens;
 
- CloseFile(OutFile);
- Erase(OutFile);
+ if Outfile<>nil then
+ begin
+   OutFile.Close;
+   OutFile.Erase;
+ end;
 
  RaiseHaltException(2);
 

--- a/src/Optimize.pas
+++ b/src/Optimize.pas
@@ -370,7 +370,7 @@ end;
 
    if TemporaryBuf[0].IndexOf('#asm:') = 0 then begin
 
-    writeln(OutFile, AsmBlock[StrToInt( copy(TemporaryBuf[0], 6, 256) )]);
+    OutFile.WriteLn( AsmBlock[StrToInt( copy(TemporaryBuf[0], 6, 256) )] );
 
     TemporaryBuf[0] := '~';
 
@@ -472,7 +472,7 @@ begin
     end;
 
   if TemporaryBuf[0] <> '~' then begin
-   if (TemporaryBuf[0] <> '') or (outTmp <> TemporaryBuf[0]) then writeln(OutFile, TemporaryBuf[0]);
+   if (TemporaryBuf[0] <> '') or (outTmp <> TemporaryBuf[0]) then OutFile.WriteLn(TemporaryBuf[0]);
 
    outTmp := TemporaryBuf[0];
   end;

--- a/src/Parser.pas
+++ b/src/Parser.pas
@@ -416,7 +416,7 @@ begin
 
 	if (ConstDataSize < 0) or (ConstDataSize > $FFFF) then
 	begin writeln('SaveToDataSegment: ', ConstDataSize);
-	      RaiseHaltException(2);
+	      RaiseHaltException(THaltException.COMPILING_ABORTED);
 	end;
 
     ftmp[0]:=0;
@@ -1662,6 +1662,7 @@ else
 
   Inc(NumIdent);
 
+  // Writeln('NumIdent='+IntToStr(NumIdent)+' ErrTokenIndex='+IntToStr(ErrTokenIndex)+' Name='+name+' Kind='+IntToStr( Kind)+' DataType='+IntToStr( DataType)+' NumAllocElements='+IntToStr( NumAllocElements)+' AllocElementType='+IntToStr( AllocElementType));
   if NumIdent > High(Ident) then
     Error(NumTok, 'Out of resources, IDENT');
 
@@ -1739,7 +1740,10 @@ else
         if (Ident[NumIdent].idType = ARRAYTOK) and (Ident[NumIdent].isAbsolute = false) and (Elements(NumIdent) = 1) then	// [0..0] ; [0..0, 0..0]
 
 	else
- 	  VarDataSize := VarDataSize + integer(Elements(NumIdent) * DataSize[AllocElementType]);
+          if ( Low(DataSize) <= AllocElementType ) and  ( AllocElementType <= High(DataSize) ) then
+          begin
+ 	    VarDataSize := VarDataSize + integer(Elements(NumIdent) * DataSize[AllocElementType]);
+          end;
 
        end;
 

--- a/src/Test-0.pas
+++ b/src/Test-0.pas
@@ -1,0 +1,139 @@
+program TestUnits;
+
+{$i define.inc}
+
+uses
+  Console,
+  Common,
+  FileIO,
+  Scanner,
+  Utilities {$IFDEF PAS2JS}
+     ,browserconsole
+ {$ENDIF};
+
+  procedure StartTest(Name: String);
+  begin
+    WriteLn('Unit Test ' + Name + ' started.');
+  end;
+
+  procedure FailTest(msg: String);
+  begin
+    WriteLn('ERROR: ' + msg);
+  end;
+
+
+  procedure EndTest(Name: String);
+  begin
+    WriteLn('Unit Test ' + Name + ' ended.');
+  end;
+
+
+  procedure TestNative(filePath: TFilePath);
+  var
+    f: TextFile;
+    s: String;
+  begin
+    StartTest('TestFileNative');
+
+    AssignFile(f, filePath);
+
+    try
+      reset(f); // Open the file for reading
+      readln(f, s);
+      writeln('Text read from file: ', s)
+
+    finally
+      CloseFile(f);
+    end;
+    EndTest('TestFileNative');
+  end;
+
+  procedure TestFileIO(filePath: TFilePath);
+  var
+    binFile: IBinaryFile;
+  var
+    c: Char;
+  begin
+    StartTest('TestFileIO');
+
+    binFile := TFileSystem.CreateBinaryFile;
+    binFile.Assign(filePath);
+    try
+      binFile.Reset;
+
+      while not binFile.EOF do
+      begin
+        c := ' ';
+        binFile.Read(c);
+        Write(c);
+        // WriteLn(IntToStr(Ord(c)));
+      end;
+      //      binFile.Read(c);
+      binFile.Close;
+    except
+      FailTest('Failed with Exception.');
+
+    end;
+    EndTest('TestFileIO');
+  end;
+
+  procedure TestUnitFile;
+  const
+    TEST_MP_FILE_PATH = 'Test-MP.pas';
+  var
+    pathList: TPathList;
+
+  begin
+    StartTest('TestUnitFile');
+    TestNative(TEST_MP_FILE_PATH);
+    TestFileIO(TEST_MP_FILE_PATH);
+
+    pathList := TPathList.Create;
+    pathList.AddFolder('Folder1');
+    pathList.AddFolder('Folder2');
+    pathList.AddFolder('Folder2'+TFileSystem.PathDelim);
+    Assert(pathList.GetSize() = 2);
+    Assert(pathList.ToString() = 'Folder1'+TFileSystem.PathDelim +';Folder2'+TFileSystem.PathDelim );
+    pathList.Free;
+
+    EndTest('TestUnitFile');
+  end;
+
+  procedure TestUnitCommon;
+  var
+    filePath: String;
+  begin
+    ;
+    StartTest('TestUnitCommon');
+
+(* Until next pull request
+    // Unit Scanner
+    Program_NAME := 'TestProgram';
+    NumTok := 0;
+    // Kind, UnitIndex, Line, Column, Value
+    AddToken(PROGRAMTOK, 1, 1, 1, 0);
+
+    // Unit Common
+    unitPathList:=TPathList.Create;
+    unitPathList.AddFolder('libnone');
+    filePath := '';
+    try
+      filePath := FindFile('TestUnit', 'unit');
+    except
+      on  ex: THaltException do
+      begin
+        Assert(ex.GetExitCode = THaltException.COMPILING_ABORTED);
+      end;
+    end;
+    Assert(filePath <> '', 'Non-existing TestUnit found');
+*)
+    EndTest('TestUnitCommon');
+  end;
+
+
+begin
+  TestUnitFile;
+  TestUnitCommon;
+
+  Writeln('Main completed.');
+end.

--- a/src/Test-MP.pas
+++ b/src/Test-MP.pas
@@ -1,0 +1,6 @@
+program test;
+
+begin
+
+  Writeln('Test completed.');
+end.

--- a/src/Utilities.pas
+++ b/src/Utilities.pas
@@ -5,37 +5,87 @@ interface
 {$i define.inc}
 {$i Types.inc}
 
-type THaltException = class
+type
+  TEnvironment = class
+    class function GetParameterCount(): Longint;
+    class function GetParameterString(const i: Longint): String;
+    class function GetParameterStringUpperCase(const i: Longint): String;
+  end;
+
+type
+  THaltException = class
+  type TExitCode = Longint;
+
+  const
+    OK: TExitCode = 0;
+    // No errors occurred, the output files were created correctly
+  const
+    COMPILING_ABORTED: TExitCode = 2;     // Errors occurred, and compiling was aborted
+  const
+    COMPILING_NOT_STARTED: TExitCode = 3;
+    // Wrong parameters were specified, and compiling was not started
+
   private
-    exitCode: LongInt;
+    exitCode: Longint;
 
   public
-    constructor Create(exitCode: LongInt);
-    function GetExitCode: LongInt;    
-end;
+    constructor Create(exitCode: Longint);
+    function GetExitCode: Longint;
+  end;
 
 // Replaces https://www.freepascal.org/docs-html/rtl/system/halt.html
-procedure RaiseHaltException( errnum: LongInt = 0 );
+procedure RaiseHaltException(errnum: Longint = 0);
 
 {$IFDEF PAS2JS}
   {$I 'include\pas2js\Utilities-PAS2JS-Interface.inc'}
 {$ELSE}
-  procedure MoveSingle(i: Integer; s: Single);
+
 {$ENDIF}
 
 implementation
 
-constructor THaltException.Create(exitCode: LongInt);
+uses SysUtils;
+
+class function TEnvironment.GetParameterCount(): Longint;
+begin
+{$IFNDEF PAS2JS}
+   Result:=ParamCount;
+{$ELSE}
+  Result := 3;
+{$ENDIF}
+end;
+
+class function TEnvironment.GetParameterString(const i: Longint): String;
+begin
+   {$IFNDEF PAS2JS}
+      Result:=ParamStr(i);
+   {$ELSE}
+  case i of
+    1: Result := 'Input.pas';
+    2: Result := '-i:lib';
+    3: Result := '-o:Output.a65';
+  end;
+   {$ENDIF}
+end;
+
+class function TEnvironment.GetParameterStringUpperCase(const i: Longint): String;
+begin
+  Result := AnsiUpperCase(GetParameterString(i));
+end;
+
+// ----------------------------------------------------------------------------
+
+constructor THaltException.Create(exitCode: Longint);
 begin
   Self.exitCode := exitCode;
 end;
 
-function THaltException.GetExitCode: LongInt;
+function THaltException.GetExitCode: Longint;
 begin
   Result := exitCode;
 end;
 
-procedure RaiseHaltException( errnum: LongInt );
+procedure RaiseHaltException(errnum: Longint);
 begin
 {$IFDEF PAS2JS}
   raise THaltException.Create(errnum);
@@ -49,10 +99,6 @@ end;
   {$I 'include\pas2js\Utilities-PAS2JS-Implementation.inc'}
 {$ELSE}
 
-procedure MoveSingle(i: Integer; s: Single);
-begin
-end;
- 
 {$ENDIF}
 
 end.

--- a/src/define.inc
+++ b/src/define.inc
@@ -1,7 +1,17 @@
+{$ASSERTIONS ON}
+
+// TODO: Should be ON but there some parts in the parser that stilly relay on array access with invalid indexes.
+{$RANGECHECKS OFF}
+
 //{$DEFINE WHILEDO}
 
 //{$DEFINE USEOPTFILE}
 
 {$DEFINE OPTIMIZECODE}
 
-{$I+}
+// The Delphi form is not accepted by PAS2JS
+{$IFNDEF PAS2JS}
+  {$I+}
+{$ELSE}
+  {$IOCHECKS ON}
+{$ENDIF}


### PR DESCRIPTION
By switching from global System procedures to IFile, we can pass complex data into and out of the process later, especially in contexts without physical files (e.g., Javascript). The previous version still had a mix of procedure and class-based usages.