### PR TITLE
Have all float types at once in Snowflake sample program

### DIFF
--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -4,3 +4,4 @@
 *.lst
 *.obx
 *.xex
+*.exe

--- a/samples/a8/graph_crossplatform/snowflake.pas
+++ b/samples/a8/graph_crossplatform/snowflake.pas
@@ -1,28 +1,27 @@
 // Koch Snowflake
 // https://en.wikipedia.org/wiki/Koch_snowflake
 
-// float16	186
-// real		197
-// single	237
+// For every supported data type, a separate unit with the same code is used.
+// Float16	186 ticks
+// Real		197 ticks
+// Single	237 ticks
 
+//FPC does not have Float16
+{$IFNDEF FPC}
+{$DEFINE HAS_FLOAT16}
+{$ENDIF}
 
 uses crt, graph, sysutils,
+     {$IFDEF HAS_FLOAT16}
+     snowflake_unit_float16 in 'snowflake_unit_float16.pas',
+     {$ENDIF}
      snowflake_unit_real in 'snowflake_unit_real.pas',
      snowflake_unit_single in 'snowflake_unit_single.pas';
-
-procedure WaitForKey;
-begin
-  repeat 
-  until KeyPressed;
-  ReadKey;
-  repeat 
-  until not KeyPressed;
-end;
 
 procedure Snowflake;
 
 const FLOAT_TYPES : array of String = [
-{$IFDEF FLOAT16} // TODO does not work yet
+{$IFDEF HAS_FLOAT16}
 'Float16',
 {$ENDIF}
 'Real',
@@ -45,7 +44,7 @@ begin
     ticks := GetTickCount;
     
     floatType:=FLOAT_TYPES[i];
-    {$IFDEF Float16}
+    {$IFDEF HAS_FLOAT16}
     if floatType = 'Float16' then snowflake_unit_float16.CreateKochSnowflake;
     {$ENDIF}
     if floatType = 'Real'    then snowflake_unit_real.CreateKochSnowflake;
@@ -53,12 +52,12 @@ begin
   
     ticks := GetTickCount - ticks;
   
-    WaitForKey;
+    ReadKey;
   
     WriteLn('Koch Snowflake with type ''',floatType,'''.');
     Writeln('Time required: ', ticks,' ticks');
     WriteLn('Press any key to continue.');
-    WaitForKey;
+    ReadKey;
 
   end;
   

--- a/samples/a8/graph_crossplatform/snowflake.pas
+++ b/samples/a8/graph_crossplatform/snowflake.pas
@@ -1,74 +1,70 @@
 // Koch Snowflake
-//
-// See https://en.wikipedia.org/wiki/Koch_snowflake
+// https://en.wikipedia.org/wiki/Koch_snowflake
 
-// Float16  186 ticks
-// Real     197 ticks
-// Single   237 ticks
+// float16	186
+// real		197
+// single	237
 
-program snowflake;
 
-uses
-  Crt,
-  graph,
-  SysUtils;
+uses crt, graph, sysutils,
+     snowflake_unit_real in 'snowflake_unit_real.pas',
+     snowflake_unit_single in 'snowflake_unit_single.pas';
+
+procedure WaitForKey;
+begin
+  repeat 
+  until KeyPressed;
+  ReadKey;
+  repeat 
+  until not KeyPressed;
+end;
+
+procedure Snowflake;
 
 const FLOAT_TYPES : array of String = [
-{$IFDEF Float16}
+{$IFDEF FLOAT16} // TODO does not work yet
 'Float16',
 {$ENDIF}
 'Real',
 'Single' ];
 
-var
-  gd, gm: Smallint;
-
-  ticks: Cardinal;
-
-{$IFDEF Float16}
-procedure CreateKochSnowflake_Float16;
-type
-  TFloat = Float16;
-{$I snowflake.inc}
-{$ENDIF}
-
-procedure CreateKochSnowflake_Real;
-type
-  TFloat = Real;
-{$I snowflake.inc}
-
-procedure CreateKochSnowflake_Single;
-type
-  TFloat = Single;
-{$I snowflake.inc}
-
+var gd, gm: SmallInt;
+var ticks: Cardinal;
+var i: Byte;
 var floatType: String;
 begin
 
-  for floatType in FLOAT_TYPES do
+  for i:=Low(FLOAT_TYPES) to High(FLOAT_TYPES) do
   begin
 
-  gd := D8bit;
-  gm := m640x480;
+    gd := D8bit;
+    gm := m640x480;
+  
+    InitGraph(gd, gm, '');
+  
+    ticks := GetTickCount;
+    
+    floatType:=FLOAT_TYPES[i];
+    {$IFDEF Float16}
+    if floatType = 'Float16' then snowflake_unit_float16.CreateKochSnowflake;
+    {$ENDIF}
+    if floatType = 'Real'    then snowflake_unit_real.CreateKochSnowflake;
+    if floatType = 'Single'  then snowflake_unit_single.CreateKochSnowflake;
+  
+    ticks := GetTickCount - ticks;
+  
+    WaitForKey;
+  
+    WriteLn('Koch Snowflake with type ''',floatType,'''.');
+    Writeln('Time required: ', ticks,' ticks');
+    WriteLn('Press any key to continue.');
+    WaitForKey;
 
-  InitGraph(gd, gm, '');
-
-  ticks := GetTickCount;
-
-  {$IFDEF Float16}
-  if floatType = 'Float16' then CreateKochSnowflake_Float16;
-  {$ENDIF}
-  if floatType = 'Real'    then CreateKochSnowflake_Real;
-  if floatType = 'Single'  then CreateKochSnowflake_Single;
-
-  ticks := GetTickCount - ticks;
-
-  repeat
-  until keypressed;
-
-  WriteLn('Koch Snowflake with type ''',floatType,''' required ', ticks,' ticks.');
   end;
+  
+ end;
 
-  while True do ;
-
+begin
+Snowflake;
 end.
+

--- a/samples/a8/graph_crossplatform/snowflake_unit.inc
+++ b/samples/a8/graph_crossplatform/snowflake_unit.inc
@@ -1,45 +1,48 @@
-(* Generic Koch Snowflake Include                *)
-(* Defined TFloat as required before using this. *)
+
+(* Generic Koch Snowflake Include               *)
+(* Define TFloat as required before using this. *)
+
+const
+  center_x = 160;
+  center_y = 115;
+
+  iterations = 3;
 
 type
-  FPoint = record
+  TFloatPoint = record
     x: TFloat;
     y: TFloat;
   end;
 
 const
-  cx = 160;
-  cy = 115;
-
   ray0 = TFloat(70.0);
   ray1 = TFloat(ray0 / 2);
 
   sqrt3 = TFloat(1.7320580756);    // SQRT(3.0)
 
-  iterations = 3;
 
-  procedure LineTo2D(ax, ay: TFloat);
-  begin
+procedure LineTo2D(ax, ay: TFloat);
+begin
 
-    LineTo(trunc(ax) + cx, trunc(ay) + cy);
+    LineTo(trunc(ax) + center_x, trunc(ay) + center_y);
 
-  end;
+end;
 
-  procedure MoveTo2D(ax, ay: TFloat);
-  begin
+procedure MoveTo2D(ax, ay: TFloat);
+begin
 
-    MoveTo(trunc(ax) + cx, trunc(ay) + cy);
+    MoveTo(trunc(ax) + center_x, trunc(ay) + center_y);
 
-  end;
+end;
 
-  procedure NextSegments(ax, ay, bx, by: TFloat; n: Byte);
+procedure NextSegments(ax, ay, bx, by: TFloat; n: Byte);
   const
     factor: TFloat = 0.288675135;  { SQRT(3) / 6 }
   var
-    middle: FPoint;
+    middle: TFloatPoint;
     xDelta: TFloat;
     yDelta: TFloat;
-    r, s, t: FPoint;
+    r, s, t: TFloatPoint;
   begin
 
     if n > 0 then
@@ -78,7 +81,7 @@ const
 
   end;
 
-  procedure KochSnowflake(a, b, c: FPoint; n: Byte);
+procedure KochSnowflake(a, b, c: TFloatPoint; n: Byte);
   begin
 
     SetColor(1);
@@ -94,11 +97,11 @@ const
     LineTo2D(a.x, a.y);
     NextSegments(c.x, c.y, a.x, a.y, n);
 
-  end {KochSnowflake};
+end;
 
-
+procedure CreateKochSnowflake;
 var
-  a, b, c: FPoint;
+  a, b, c: TFloatPoint;
 
 begin
 
@@ -112,7 +115,5 @@ begin
   c.y := ray1 * SQRT3;
 
   KochSnowflake(a, b, c, iterations);
-
 end;
-
 

--- a/samples/a8/graph_crossplatform/snowflake_unit_float16.pas
+++ b/samples/a8/graph_crossplatform/snowflake_unit_float16.pas
@@ -1,0 +1,16 @@
+unit snowflake_unit_float16;
+
+interface
+
+procedure CreateKochSnowflake;
+
+implementation
+
+uses graph;
+
+type
+  TFloat = Float16;
+
+{$I snowflake_unit.inc}
+
+end.

--- a/samples/a8/graph_crossplatform/snowflake_unit_real.pas
+++ b/samples/a8/graph_crossplatform/snowflake_unit_real.pas
@@ -1,0 +1,16 @@
+unit snowflake_unit_real;
+
+interface
+
+procedure CreateKochSnowflake;
+
+implementation
+
+uses graph;
+
+type
+  TFloat = Real;
+
+{$I snowflake_unit.inc}
+
+end.

--- a/samples/a8/graph_crossplatform/snowflake_unit_single.pas
+++ b/samples/a8/graph_crossplatform/snowflake_unit_single.pas
@@ -1,0 +1,16 @@
+unit snowflake_unit_single;
+
+interface
+
+procedure CreateKochSnowflake;
+
+implementation
+
+uses graph;
+
+type
+  TFloat = Single;
+
+{$I snowflake_unit.inc}
+
+end.

--- a/src/TestUnits.pas
+++ b/src/TestUnits.pas
@@ -3,7 +3,7 @@ program TestUnits;
 {$I Defines.inc}
 
 uses
-  Crt, Common, Console, Diagnostic, FileIO, MathEvaluate, Parser, Scanner, Optimize, Types, Utilities,
+  Crt, Common, CommonTypes, Console, Diagnostic, FileIO, MathEvaluate, Parser, Scanner, Optimize, Types, Utilities,
   SysUtils;
 
   procedure StartTest(Name: String);


### PR DESCRIPTION
The previous version of Snowflake required changing the TFloat type in the source code.
The new version creates three separate units, allowing all three types to be used and compared within a single program.
This simplifies compilation and allows for direct comparison in a single run.