### PR TITLE
Way2js4 - Make TUnit a class

### DIFF
--- a/bin/javascript/mp.js
+++ b/bin/javascript/mp.js
@@ -1821,12 +1821,6 @@ rtl.module("System",[],function () {
       $impl.WriteBuf = "";
     };
   };
-  this.SetWriteCallBack = function (H) {
-    var Result = null;
-    Result = $impl.WriteCallBack;
-    $impl.WriteCallBack = H;
-    return Result;
-  };
   $mod.$implcode = function () {
     $impl.WriteBuf = "";
     $impl.WriteCallBack = null;
@@ -1932,7 +1926,7 @@ rtl.module("SysUtils",["System","RTLConsts","JS"],function () {
       return this;
     };
     this.GetJSLocale = function () {
-      return Intl.DateTimeFormat().resolvedOptions().locale;
+      return "en_EN"; // Intl.DateTimeFormat().resolvedOptions().locale;
     };
     this.Create = function () {
       var Result = $mod.TFormatSettings.$new();
@@ -3210,132 +3204,6 @@ rtl.module("SysUtils",["System","RTLConsts","JS"],function () {
     $mod.LongDayNames = $impl.DefaultLongDayNames.slice(0);
   };
 },[]);
-rtl.module("weborworker",["System","JS"],function () {
-  "use strict";
-  var $mod = this;
-});
-rtl.module("Web",["System","JS","weborworker"],function () {
-  "use strict";
-  var $mod = this;
-});
-rtl.module("Classes",["System","RTLConsts","SysUtils","JS"],function () {
-  "use strict";
-  var $mod = this;
-  var $impl = $mod.$impl;
-  rtl.createClass(this,"TLoadHelper",pas.System.TObject,function () {
-  });
-  this.SetLoadHelperClass = function (aClass) {
-    var Result = null;
-    Result = $impl.GlobalLoadHelper;
-    $impl.GlobalLoadHelper = aClass;
-    return Result;
-  };
-  $mod.$implcode = function () {
-    $impl.GlobalLoadHelper = null;
-    $impl.ClassList = null;
-  };
-  $mod.$init = function () {
-    $impl.ClassList = new Object();
-  };
-},[]);
-rtl.module("Rtl.BrowserLoadHelper",["System","Classes","SysUtils","JS","Web"],function () {
-  "use strict";
-  var $mod = this;
-  rtl.createClass(this,"TBrowserLoadHelper",pas.Classes.TLoadHelper,function () {
-  });
-  $mod.$init = function () {
-    pas.Classes.SetLoadHelperClass($mod.TBrowserLoadHelper);
-  };
-});
-rtl.module("browserconsole",["System","JS","Web","Rtl.BrowserLoadHelper","SysUtils"],function () {
-  "use strict";
-  var $mod = this;
-  var $impl = $mod.$impl;
-  this.BrowserLineBreak = "\n";
-  this.DefaultMaxConsoleLines = 25;
-  this.DefaultConsoleStyle = ".pasconsole { " + this.BrowserLineBreak + "font-family: courier;" + this.BrowserLineBreak + "font-size: 14px;" + this.BrowserLineBreak + "background: #FFFFFF;" + this.BrowserLineBreak + "color: #000000;" + this.BrowserLineBreak + "display: block;" + this.BrowserLineBreak + "}";
-  this.ConsoleElementID = "";
-  this.ConsoleStyle = "";
-  this.MaxConsoleLines = 0;
-  this.ConsoleLinesToBrowserLog = false;
-  this.ResetConsole = function () {
-    if ($impl.LinesParent === null) return;
-    while ($impl.LinesParent.firstElementChild !== null) $impl.LinesParent.removeChild($impl.LinesParent.firstElementChild);
-    $impl.AppendLine();
-  };
-  this.InitConsole = function () {
-    if ($impl.ConsoleElement === null) return;
-    if ($impl.ConsoleElement.nodeName.toLowerCase() !== "body") {
-      while ($impl.ConsoleElement.firstElementChild !== null) $impl.ConsoleElement.removeChild($impl.ConsoleElement.firstElementChild);
-    };
-    $impl.StyleElement = document.createElement("style");
-    $impl.StyleElement.innerText = $mod.ConsoleStyle;
-    $impl.ConsoleElement.appendChild($impl.StyleElement);
-    $impl.LinesParent = document.createElement("div");
-    $impl.ConsoleElement.appendChild($impl.LinesParent);
-  };
-  this.HookConsole = function () {
-    $impl.ConsoleElement = null;
-    if ($mod.ConsoleElementID !== "") $impl.ConsoleElement = document.getElementById($mod.ConsoleElementID);
-    if ($impl.ConsoleElement === null) $impl.ConsoleElement = document.body;
-    if ($impl.ConsoleElement === null) return;
-    $mod.InitConsole();
-    $mod.ResetConsole();
-    pas.System.SetWriteCallBack($impl.WriteConsole);
-  };
-  $mod.$implcode = function () {
-    $impl.LastLine = null;
-    $impl.StyleElement = null;
-    $impl.LinesParent = null;
-    $impl.ConsoleElement = null;
-    $impl.AppendLine = function () {
-      var CurrentCount = 0;
-      var S = null;
-      CurrentCount = 0;
-      S = $impl.LinesParent.firstChild;
-      while (S != null) {
-        CurrentCount += 1;
-        S = S.nextSibling;
-      };
-      while (CurrentCount > $mod.MaxConsoleLines) {
-        CurrentCount -= 1;
-        $impl.LinesParent.removeChild($impl.LinesParent.firstChild);
-      };
-      $impl.LastLine = document.createElement("div");
-      $impl.LastLine.className = "pasconsole";
-      $impl.LinesParent.appendChild($impl.LastLine);
-    };
-    $impl.EscapeString = function (S) {
-      var Result = "";
-      var CL = "";
-      CL = pas.SysUtils.StringReplace(S,"<","&lt;",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      CL = pas.SysUtils.StringReplace(CL,">","&gt;",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      CL = pas.SysUtils.StringReplace(CL," ","&nbsp;",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      CL = pas.SysUtils.StringReplace(CL,"\r\n","<br>",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      CL = pas.SysUtils.StringReplace(CL,"\n","<br>",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      CL = pas.SysUtils.StringReplace(CL,"\r","<br>",rtl.createSet(pas.SysUtils.TStringReplaceFlag.rfReplaceAll));
-      Result = CL;
-      return Result;
-    };
-    $impl.WriteConsole = function (S, NewLine) {
-      var CL = "";
-      CL = $impl.LastLine.innerHTML;
-      CL = CL + $impl.EscapeString("" + S);
-      $impl.LastLine.innerHTML = CL;
-      if (NewLine) {
-        if ($mod.ConsoleLinesToBrowserLog) window.console.log($impl.LastLine.innerText);
-        $impl.AppendLine();
-      };
-    };
-  };
-  $mod.$init = function () {
-    $mod.ConsoleLinesToBrowserLog = true;
-    $mod.ConsoleElementID = "pasjsconsole";
-    $mod.ConsoleStyle = $mod.DefaultConsoleStyle;
-    $mod.MaxConsoleLines = 25;
-    $mod.HookConsole();
-  };
-},[]);
 rtl.module("CommonTypes",["System"],function () {
   "use strict";
   var $mod = this;
@@ -4394,17 +4262,6 @@ rtl.module("Utilities",["System"],function () {
   this.RaiseHaltException = function (errnum) {
     throw $mod.THaltException.$create("Create$1",[errnum]);
   };
-  rtl.recNewT(this,"TFormatSettings",function () {
-    this.DecimalSeparator = "\x00";
-    this.$eq = function (b) {
-      return this.DecimalSeparator === b.DecimalSeparator;
-    };
-    this.$assign = function (s) {
-      this.DecimalSeparator = s.DecimalSeparator;
-      return this;
-    };
-  });
-  this.DefaultFormatSettings = this.TFormatSettings.$clone({CurrencyFormat: 1, NegCurrFormat: 5, ThousandSeparator: ",", DecimalSeparator: ".", CurrencyDecimals: 2, DateSeparator: "-", TimeSeparator: ":", ListSeparator: ",", CurrencyString: "$", ShortDateFormat: "d/m/y", LongDateFormat: 'dd" "mmmm" "yyyy', TimeAMString: "AM", TimePMString: "PM", ShortTimeFormat: "hh:nn", LongTimeFormat: "hh:nn:ss", ShortMonthNames: ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"], LongMonthNames: ["January","February","March","April","May","June","July","August","September","October","November","December"], ShortDayNames: ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"], LongDayNames: ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"], TwoDigitYearCenturyWindow: 50});
   this.AnsiLowerCase = function (s) {
     var Result = "";
     Result = pas.SysUtils.LowerCase(s);
@@ -5311,12 +5168,12 @@ rtl.module("Common",["System","SysUtils","CommonTypes","Datatypes","FileIO","Mem
   this.CodePosStackTop = 0;
   this.BreakPosStackTop = 0;
   this.VarDataSize = 0;
-  this.ShrShlCnt = 0;
   this.NumStaticStrCharsTmp = 0;
   this.AsmBlockIndex = 0;
   this.IfCnt = 0;
   this.CaseCnt = 0;
   this.IfdefLevel = 0;
+  this.ShrShlCnt = 0;
   this.pass = 0;
   this.iOut = -1;
   this.CODEORIGIN_BASE = -1;
@@ -33763,7 +33620,7 @@ rtl.module("Compiler",["System","FileIO"],function () {
   var $impl = $mod.$impl;
   this.CompilerTitle = function () {
     var Result = "";
-    Result = "Mad Pascal Compiler version " + pas.Common.title + " [" + "2025/5/3" + "] for MOS 6502 CPU";
+    Result = "Mad Pascal Compiler version " + pas.Common.title + " [" + "2025/5/4" + "] for MOS 6502 CPU";
     return Result;
   };
   var PI_VALUE = 3;
@@ -33777,7 +33634,6 @@ rtl.module("Compiler",["System","FileIO"],function () {
     pas.Common.IFTmpPosStack = rtl.arraySetLength(pas.Common.IFTmpPosStack,0,1);
     pas.Common.Tok[pas.Common.NumTok].Line = 0;
     pas.Common.Defines[0].Name = pas.Utilities.AnsiUpperCase(pas.Common.target.Name);
-    pas.Utilities.DefaultFormatSettings.DecimalSeparator = ".";
     pas.Console.TextColor(15);
     pas.System.Writeln("Compiling " + pas.Common.UnitName[0].Name);
     pas.Scanner.TokenizeProgram(true);
@@ -44960,7 +44816,7 @@ rtl.module("Diagnostic",["System"],function () {
     };
   };
 },["SysUtils","Common","Datatypes","FileIO","Tokens"]);
-rtl.module("program",["System","SysUtils","browserconsole","Common","Compiler","Console","Diagnostic","FileIO","Messages","Targets","Tokens","Utilities"],function () {
+rtl.module("program",["System","SysUtils","Common","Compiler","Console","Diagnostic","FileIO","Messages","Targets","Tokens","Utilities"],function () {
   "use strict";
   var $mod = this;
   this.Syntax = function (ExitCode) {

--- a/projects/TestMadPascal.lpi
+++ b/projects/TestMadPascal.lpi
@@ -30,6 +30,12 @@
             <WorkingDirectory Value="C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\src\tests"/>
           </local>
         </Mode>
+        <Mode Name="PacMad">
+          <local>
+            <CommandLineParams Value="-iPath:..\..\..\..\lib pacmad.pas"/>
+            <WorkingDirectory Value="C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\samples\a8\games\PacMad"/>
+          </local>
+        </Mode>
       </Modes>
     </RunParams>
     <Units>

--- a/projects/TestMadPascal.lpi
+++ b/projects/TestMadPascal.lpi
@@ -26,7 +26,8 @@
       <Modes>
         <Mode Name="default">
           <local>
-            <CommandLineParams Value="-iPath:..\lib ..\src\tests\Test-MP.pas"/>
+            <CommandLineParams Value="-iPath:..\..\lib TestMP.pas"/>
+            <WorkingDirectory Value="C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\src\tests"/>
           </local>
         </Mode>
       </Modes>
@@ -535,6 +536,18 @@
       </Unit>
       <Unit>
         <Filename Value="..\src\CompilerTypes.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="..\src\tests\TestUnit.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="..\src\tests\TestMP.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="..\src\tests\TestInclude.inc"/>
         <IsPartOfProject Value="True"/>
       </Unit>
     </Units>

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -94,7 +94,8 @@ var
 
   optimize: record
     use: Boolean;
-    unitIndex, line, old: Integer;
+    SourceCodeFile: TUnit;
+    line, old: Integer;
     end;
 
   codealign: record

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -142,7 +142,7 @@ procedure DefineStaticString(StrTokenIndex: TTokenIndex; StrValue: String);
 
 procedure DefineFilename(StrTokenIndex: TTokenIndex; StrValue: String);
 
-function FindFile(Name: String; ftyp: TString): String; overload;
+function FindFile(Name: String; ftyp: TString): TFilePath; overload;
 
 function GetCommonConstType(ErrTokenIndex: TTokenIndex; DstType, SrcType: TDataType; err: Boolean = True): Boolean;
 
@@ -167,7 +167,7 @@ uses Messages, Utilities;
 // ----------------------------------------------------------------------------
 
 
-function FindFile(Name: String; ftyp: TString): String; overload;
+function FindFile(Name: String; ftyp: TString): TFilePath; overload;
 var
   msg: IMessage;
 begin
@@ -234,8 +234,7 @@ end;
 
 function GetUnit(const UnitIndex: TUnitIndex): TUnit;
 begin
-  assert(UnitIndex >= Low(UnitList.UnitArray));
-  Result := UnitList.UnitArray[UnitIndex];
+  Result := UnitList.GetUnit(UnitIndex);
 end;
 
 

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -44,8 +44,7 @@ var
   NumIdent: Integer;
   Ident: array [1..MAXIDENTS] of TIdentifier;
 
-  NumUnits: Integer;
-  UnitArray: array [1..MAXUNITS + MAXUNITS] of TUnit;  // {$include ...} -> UnitName[MAXUNITS..]
+  UnitList: TUnitList;
 
 
   IFTmpPosStack: array of Integer;
@@ -83,7 +82,7 @@ var
     msgWarning: TStringList;
     msgNote: TStringList;
     msgUser: TStringList;
-  end;
+    end;
 
   LinkObj: TStringArray;
   unitPathList: TPathList;
@@ -119,6 +118,7 @@ var
 {$ENDIF}
 
 // ----------------------------------------------------------------------------
+function NumUnits: Integer;
 function NumTok: Integer;
 
 procedure AddDefine(const defineName: TDefineName);
@@ -234,8 +234,8 @@ end;
 
 function GetUnit(const UnitIndex: TUnitIndex): TUnit;
 begin
-  assert(UnitIndex >= Low(UnitArray));
-  Result := UnitArray[UnitIndex];
+  assert(UnitIndex >= Low(UnitList.UnitArray));
+  Result := UnitList.UnitArray[UnitIndex];
 end;
 
 
@@ -615,6 +615,15 @@ begin
   //StaticStringData[NumStaticStrChars] := 0;
   //Inc(NumStaticStrChars);
 
+end;
+
+// The function is currently kept for compatibility, simulating the previous global variable.
+function NumUnits: Integer;
+begin
+  if unitList <> nil then
+  begin
+    Result := UnitList.Size;
+  end;
 end;
 
 // The function is currently kept for compatibility, simulating the previous global variable.

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -127,7 +127,6 @@ function SearchDefine(const defineName: TDefineName): TDefineIndex;
 
 procedure AddPath(folderPath: TFolderPath);
 function GetUnit(const UnitIndex: TUnitIndex): TUnit;
-function GetUnitName(const UnitIndex: TUnitIndex): TUnitName;
 
 procedure CheckArrayIndex(i: TTokenIndex; IdentIndex: TIdentIndex; ArrayIndex: TIdentIndex; ArrayIndexType: TDataType);
 
@@ -238,11 +237,6 @@ begin
   Result := UnitList.GetUnit(UnitIndex);
 end;
 
-
-function GetUnitName(const UnitIndex: TUnitIndex): TUnitName;
-begin
-  Result := GetUnit(UnitIndex).Name;
-end;
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -4,7 +4,7 @@ unit Common;
 
 interface
 
-uses SysUtils, CommonTypes, CompilerTypes, Datatypes, FileIO, Memory, StringUtilities, Targets, Tokens;
+uses Classes, SysUtils, CommonTypes, CompilerTypes, Datatypes, FileIO, Memory, StringUtilities, Targets, Tokens;
 
 const
   title = '1.7.2';
@@ -79,7 +79,11 @@ var
 
   optyA, optyY, optyBP2, optyFOR0, optyFOR1, optyFOR2, optyFOR3: TString; // Initialized in ResetOpty
 
-  msgWarning, msgNote, msgUser: TStringArray;
+  msgLists: record
+    msgWarning: TStringList;
+    msgNote: TStringList;
+    msgUser: TStringList;
+  end;
 
   LinkObj: TStringArray;
   unitPathList: TPathList;

--- a/src/Common.pas
+++ b/src/Common.pas
@@ -471,7 +471,7 @@ end;
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-
+// TOO Move core to TDataType
 function GetCommonConstType(ErrTokenIndex: TTokenIndex; DstType, SrcType: TDataType; err: Boolean = True): Boolean;
 begin
 
@@ -512,6 +512,7 @@ end;
 // ----------------------------------------------------------------------------
 
 
+// TOO Move core to TDataType
 function GetCommonType(ErrTokenIndex: TTokenIndex; LeftType, RightType: TDataType): TDataType;
 begin
 
@@ -612,14 +613,13 @@ begin
 
 end;
 
+// The function is currently kept for compatibility, simulating the previous global variable.
 function NumTok: Integer;
 begin
   if tokenList <> nil then
   begin
     Result := tokenList.Size;
   end;
-  // TODO
-  //Writeln('NumTok=',Result);
 end;
 
 end.

--- a/src/CommonTypes.pas
+++ b/src/CommonTypes.pas
@@ -18,6 +18,7 @@ type TInteger = Integer;
 {$ENDIF}
 
 
+
 implementation
 
 end.

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -4,12 +4,12 @@ interface
 
 {$I Defines.inc}
 
-uses FileIO;
+uses FileIO, CompilerTypes;
 
 function CompilerTitle: String;
 
 procedure Initialize;
-procedure Main(const unitPathList: TPathList);
+procedure Main(const programUnit: TUnit; const unitPathList: TPathList);
 procedure Free;
 
 implementation
@@ -19,7 +19,6 @@ uses
   Math, // Required for Min(), do not remove
   Common,
   CommonTypes,
-  CompilerTypes,
   Console,
   Datatypes,
   MathEvaluate,
@@ -1109,7 +1108,7 @@ begin
   StopOptimization;
 
   common.optimize.use := True;
-    common.optimize.unitIndex := Tok[i].SourceCodeFile.UnitIndex;
+  common.optimize.SourceCodeFile := Tok[i].SourceCodeFile;
   common.optimize.line := Tok[i].Line;
 
 end;
@@ -18968,7 +18967,7 @@ end;  //CompileProgram
 //                                 Compiler Main
 // ----------------------------------------------------------------------------
 
-procedure Main(const unitPathList: TPathList);
+procedure Main(const programUnit: TUnit; const unitPathList: TPathList);
 
 {$IFNDEF PAS2JS}
 const
@@ -19005,8 +19004,7 @@ begin
 
   TextColor(WHITE);
 
-  Assert(NumUnits = 1); // TODO
-  Writeln('Compiling ' + GetUnit(1).Name);
+  Writeln('Compiling ' + programUnit.Name);
 
   // ----------------------------------------------------------------------------
   // Set defines for first pass;

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -12638,7 +12638,7 @@ begin
     TTokenKind.INFOTOK:
     begin
 
-      if Pass = TPass.CODE_GENERATION then writeln('User defined: ' + msgUser[Tok[i].Value]);
+      if Pass = TPass.CODE_GENERATION then writeln('User defined: ' + msgLists.msgUser[Tok[i].Value]);
 
       Result := i;
     end;
@@ -16894,7 +16894,7 @@ begin
 
     if Tok[i].Kind = TTokenKind.INFOTOK then
     begin
-      if Pass = TPass.CODE_GENERATION then writeln('User defined: ' + msgUser[Tok[i].Value]);
+      if Pass = TPass.CODE_GENERATION then writeln('User defined: ' + msgLists.msgUser[Tok[i].Value]);
       Inc(i, 2);
     end;
 

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -1109,7 +1109,7 @@ begin
   StopOptimization;
 
   common.optimize.use := True;
-  common.optimize.unitIndex := Tok[i].UnitIndex;
+    common.optimize.unitIndex := Tok[i].SourceCodeFile.UnitIndex;
   common.optimize.line := Tok[i].Line;
 
 end;
@@ -16932,20 +16932,20 @@ begin
     begin
       asm65separator;
 
-      DefineIdent(i, GetUnit(Tok[i].UnitIndex).Name, UNITTYPE, TDataType.UNTYPETOK, 0, TDataType.UNTYPETOK, 0);
-      Ident[NumIdent].UnitIndex := Tok[i].UnitIndex;
+      DefineIdent(i, Tok[i].SourceCodeFile.Name, UNITTYPE, TDataType.UNTYPETOK, 0, TDataType.UNTYPETOK, 0);
+      Ident[NumIdent].UnitIndex := Tok[i].SourceCodeFile.UnitIndex;
 
       //   writeln(UnitArray[Tok[i].UnitIndex].Name,',',Ident[NumIdent].UnitIndex,',',Tok[i].UnitIndex);
 
       asm65;
-      asm65('.local'#9 + GetUnit(Tok[i].UnitIndex).Name, '; UNIT');
+      asm65('.local'#9 + Tok[i].SourceCodeFile.Name, '; UNIT');
 
-      UnitNameIndex := Tok[i].UnitIndex;
+      UnitNameIndex := Tok[i].SourceCodeFile.UnitIndex;
 
       CheckTok(i + 1, TTokenKind.UNITTOK);
       CheckTok(i + 2, TTokenKind.IDENTTOK);
 
-      if Tok[i + 2].Name <> GetUnit(Tok[i].UnitIndex).Name then
+      if Tok[i + 2].Name <> Tok[i].SourceCodeFile.Name then
         Error(i + 2, 'Illegal unit name: ' + Tok[i + 2].Name);
 
       CheckTok(i + 3, TTokenKind.SEMICOLONTOK);
@@ -16974,7 +16974,7 @@ begin
       VarRegister := 0;
 
       asm65;
-      asm65('.endl', '; UNIT ' + GetUnit(Tok[i].UnitIndex).Name);
+      asm65('.endl', '; UNIT ' + Tok[i].SourceCodeFile.Name);
 
       j := NumIdent;
 

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -12513,9 +12513,10 @@ begin
                   // dla PROC, FUNC -> Ident[GetIdentIndex(Tok[k].Name)].NumAllocElements -> oznacza liczbe parametrow takiej procedury/funkcji
 
                     if (VarType in Pointers) and ((ExpressionType in Pointers) and
-                      (Tok[k].Kind = TTokenKind.IDENTTOK)) and (not
-                      (Ident[IdentIndex].AllocElementType in Pointers + [TDataType.RECORDTOK, TDataType.OBJECTTOK]) and
-                      not (Ident[GetIdentIndex(Tok[k].Name)].AllocElementType in Pointers +
+                      (Tok[k].Kind = TTokenKind.IDENTTOK)) and
+                      (not (Ident[IdentIndex].AllocElementType in Pointers +
+                      [TDataType.RECORDTOK, TDataType.OBJECTTOK]) and not
+                      (Ident[GetIdentIndex(Tok[k].Name)].AllocElementType in Pointers +
                       [TDataType.RECORDTOK, TDataType.OBJECTTOK])) (* and
        (({GetDataSize( TDataType.Ident[IdentIndex].AllocElementType] *} Ident[IdentIndex].NumAllocElements > 1) and ({GetDataSize( TDataType.Ident[GetIdentIndex(Tok[k].Name)].AllocElementType] *} Ident[GetIdentIndex(Tok[k].Name)].NumAllocElements > 1)) *) then
                     begin
@@ -17246,7 +17247,8 @@ begin
 
         yes := True;
         for j := 1 to Common.UnitList.UnitArray[UnitNameIndex].Units do
-          if (Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[j] = Tok[i].Name) or (Tok[i].Name = 'SYSTEM') then
+          if (Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[j] = Tok[i].Name) or
+            (Tok[i].Name = 'SYSTEM') then
             yes := False;
 
         if yes then
@@ -17257,7 +17259,8 @@ begin
           if GetUnit(UnitNameIndex).Units > MAXALLOWEDUNITS then
             Error(i, 'Out of resources, MAXALLOWEDUNITS');
 
-          Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[Common.UnitList.UnitArray[UnitNameIndex].Units] := Tok[i].Name;
+          Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[Common.UnitList.UnitArray[UnitNameIndex].Units] :=
+            Tok[i].Name;
 
         end;
 
@@ -19017,7 +19020,7 @@ begin
 
   // TODO: Method AddUnit
   // Add default unit 'system.pas'
-  UnitList.AddUnit( 'SYSTEM',  FindFile('system.pas', 'unit'));
+  UnitList.AddUnit(TSourceFileType.UNIT_FILE, 'SYSTEM', FindFile('system.pas', 'unit'));
 
   scanner.TokenizeProgram(False);
 

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -19010,14 +19010,14 @@ begin
   // Set defines for first pass;
   scanner := TScanner.Create;
 
-  scanner.TokenizeProgram(True);
+  scanner.TokenizeProgram(programUnit, True);
 
   if NumTok = 0 then Error(1, '');
 
   // Add default unit 'system.pas'
   UnitList.AddUnit(TSourceFileType.UNIT_FILE, 'SYSTEM', FindFile('system.pas', 'unit'));
 
-  scanner.TokenizeProgram(False);
+  scanner.TokenizeProgram(programUnit, False);
 
   // ----------------------------------------------------------------------------
 

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -1103,7 +1103,7 @@ end;
 // ----------------------------------------------------------------------------
 
 
-procedure StartOptimization(i: Integer);
+procedure StartOptimization(i: TTokenIndex);
 begin
 
   StopOptimization;
@@ -17246,21 +17246,19 @@ begin
         CheckTok(i, TTokenKind.IDENTTOK);
 
         yes := True;
-        for j := 1 to Common.UnitList.UnitArray[UnitNameIndex].Units do
-          if (Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[j] = Tok[i].Name) or
-            (Tok[i].Name = 'SYSTEM') then
+        for j := 1 to GetUnit(UnitNameIndex).Units do
+          if (GetUnit(UnitNameIndex).AllowedUnitNames[j] = Tok[i].Name) or (Tok[i].Name = 'SYSTEM') then
             yes := False;
 
         if yes then
         begin
 
-          Inc(Common.UnitList.UnitArray[UnitNameIndex].Units);
+          Inc(GetUnit(UnitNameIndex).Units);
 
           if GetUnit(UnitNameIndex).Units > MAXALLOWEDUNITS then
             Error(i, 'Out of resources, MAXALLOWEDUNITS');
 
-          Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[Common.UnitList.UnitArray[UnitNameIndex].Units] :=
-            Tok[i].Name;
+          GetUnit(UnitNameIndex).AllowedUnitNames[GetUnit(UnitNameIndex).Units] := Tok[i].Name;
 
         end;
 
@@ -18671,7 +18669,7 @@ end;
   asm65('.macro'#9'UNITINITIALIZATION');
 
   for j := NumUnits downto 2 do
-    if GetUnit(j).Name <> '' then
+    if GetUnit(j).IsRelevant then
     begin
 
       asm65;
@@ -18686,7 +18684,7 @@ end;
   asm65separator;
 
   for j := NumUnits downto 2 do
-    if GetUnit(j).Name <> '' then
+    if GetUnit(j).IsRelevant then
     begin
       asm65;
       asm65(#9'ift .SIZEOF(MAIN.' + GetUnit(j).Name + ') > 0');
@@ -19018,7 +19016,6 @@ begin
 
   if NumTok = 0 then Error(1, '');
 
-  // TODO: Method AddUnit
   // Add default unit 'system.pas'
   UnitList.AddUnit(TSourceFileType.UNIT_FILE, 'SYSTEM', FindFile('system.pas', 'unit'));
 
@@ -19090,7 +19087,7 @@ begin
   PublicSection := True;
 
   // TODO Why here?
-  for i := 1 to High(Common.UnitList.UnitArray) do Common.UnitList.UnitArray[i].Units := 0;
+  UnitList.ClearAllowedUnitNames;
 
   iOut := 0;
   outTmp := '';

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -17245,19 +17245,19 @@ begin
         CheckTok(i, TTokenKind.IDENTTOK);
 
         yes := True;
-        for j := 1 to UnitArray[UnitNameIndex].Units do
-          if (UnitArray[UnitNameIndex].AllowedUnitNames[j] = Tok[i].Name) or (Tok[i].Name = 'SYSTEM') then
+        for j := 1 to Common.UnitList.UnitArray[UnitNameIndex].Units do
+          if (Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[j] = Tok[i].Name) or (Tok[i].Name = 'SYSTEM') then
             yes := False;
 
         if yes then
         begin
 
-          Inc(UnitArray[UnitNameIndex].Units);
+          Inc(Common.UnitList.UnitArray[UnitNameIndex].Units);
 
           if GetUnit(UnitNameIndex).Units > MAXALLOWEDUNITS then
             Error(i, 'Out of resources, MAXALLOWEDUNITS');
 
-          UnitArray[UnitNameIndex].AllowedUnitNames[UnitArray[UnitNameIndex].Units] := Tok[i].Name;
+          Common.UnitList.UnitArray[UnitNameIndex].AllowedUnitNames[Common.UnitList.UnitArray[UnitNameIndex].Units] := Tok[i].Name;
 
         end;
 
@@ -19016,9 +19016,8 @@ begin
   if NumTok = 0 then Error(1, '');
 
   // TODO: Method AddUnit
-  Inc(NumUnits);
-  UnitArray[NumUnits].Name := 'SYSTEM';    // default UNIT 'system.pas'
-  UnitArray[NumUnits].Path := FindFile('system.pas', 'unit');
+  // Add default unit 'system.pas'
+  UnitList.AddUnit( 'SYSTEM',  FindFile('system.pas', 'unit'));
 
   scanner.TokenizeProgram(False);
 
@@ -19088,7 +19087,7 @@ begin
   PublicSection := True;
 
   // TODO Why here?
-  for i := 1 to High(UnitArray) do UnitArray[i].Units := 0;
+  for i := 1 to High(Common.UnitList.UnitArray) do Common.UnitList.UnitArray[i].Units := 0;
 
   iOut := 0;
   outTmp := '';

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -223,6 +223,7 @@ type
 
   TToken = class
     TokenIndex: TTokenIndex;
+    SourceCodeFile: TUnit;
     UnitIndex: TUnitIndex;
     Column: Smallint;
     Line: Integer;
@@ -237,7 +238,9 @@ type
     StrAddress: Word;
     StrLength: Word;
 
+    function GetSourceCodeFile: TUnit;
     function GetSpelling: TString;
+
   end;
 
   // A token list owns token instances.
@@ -250,7 +253,7 @@ type
 
     function Size: Integer;
     procedure Clear;
-    function AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger): TToken;
+    function AddToken(Kind: TTokenKind; SourceCodeFile: TUnit; Line, Column: Integer; Value: TInteger): TToken;
     procedure RemoveToken;
 
     function GetTokenSpellingAtIndex(const tokenIndex: TTokenIndex): TString;
@@ -367,6 +370,17 @@ function GetIOBits(const ioCode: TIOCode): TIOBits;
 
 implementation
 
+function TToken.GetSourceCodeFile: TUnit;
+begin
+  Result := SourceCodeFile;
+end;
+
+function TToken.GetSpelling: TString;
+begin
+  Result := GetHumanReadbleTokenSpelling(kind);
+end;
+
+
 constructor TTokenList.Create(const tokenArrayPointer: TTokenArrayPointer);
 begin
   self.tokenArrayPointer := tokenArrayPointer;
@@ -394,10 +408,12 @@ begin
   tokenArrayPointer^[0] := TToken.Create;
 end;
 
-function TTokenList.AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger): TToken;
+function TTokenList.AddToken(Kind: TTokenKind; SourceCodeFile: TUnit; Line, Column: Integer; Value: TInteger): TToken;
 var
   i: Integer;
 begin
+  assert(SourceCodeFile <> nil, 'No source code file specified');
+
   Result := TToken.Create;
 
   // if NumTok > MAXTOKENS then
@@ -405,7 +421,8 @@ begin
   i := size + 1;
 
   Result.TokenIndex := i;
-  Result.UnitIndex := UnitIndex;
+  Result.SourceCodeFile := SourceCodeFile;
+  Result.UnitIndex:=SourceCodeFile.UnitIndex;
   Result.Kind := Kind;
   Result.Value := Value;
 
@@ -443,11 +460,6 @@ begin
   tokenArrayPointer^[i] := nil;
   SetLength(tokenArrayPointer^, i);
 
-end;
-
-function TToken.GetSpelling: TString;
-begin
-  Result := GetHumanReadbleTokenSpelling(kind);
 end;
 
 

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -224,7 +224,7 @@ type
   TToken = class
     TokenIndex: TTokenIndex;
     SourceCodeFile: TUnit;
-    UnitIndex: TUnitIndex;
+    // UnitIndex: TUnitIndex;
     Column: Smallint;
     Line: Integer;
     Kind: TTokenKind;
@@ -422,7 +422,7 @@ begin
 
   Result.TokenIndex := i;
   Result.SourceCodeFile := SourceCodeFile;
-  Result.UnitIndex:=SourceCodeFile.UnitIndex;
+  // Result.UnitIndex:=SourceCodeFile.UnitIndex;
   Result.Kind := Kind;
   Result.Value := Value;
 

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -176,16 +176,32 @@ type
     Field: array [0..MAXFIELDS] of TField;
   end;
 
+  TUnitName = TName;
   TUnitIndex = Smallint;
 
-
-  TUnitName = TName;
-
-  TUnit = record
+  TUnit = class
     Name: TUnitName;
     Path: TFilePath;
     Units: Integer;
     AllowedUnitNames: array [1..MAXALLOWEDUNITS] of TUnitName;
+  end;
+
+  TUnitList = class
+  public
+
+
+    constructor Create();
+    destructor Free;
+
+    function Size: Integer;
+    function AddUnit(Name: TUnitName; Path: TFilePath): TUnit;
+
+  var
+    unitArray: array [1..MAXUNITS + MAXUNITS] of TUnit;  // {$include ...} -> UnitName[MAXUNITS..]
+
+  private
+  var
+    Count: Integer;
   end;
 
   IUnit = interface
@@ -228,6 +244,7 @@ type
     procedure RemoveToken;
 
     function GetTokenSpellingAtIndex(const tokenIndex: TTokenIndex): TString;
+
   private
 
   var
@@ -340,11 +357,6 @@ function GetIOBits(const ioCode: TIOCode): TIOBits;
 
 implementation
 
-function TToken.GetSpelling: TString;
-begin
-  Result := GetHumanReadbleTokenSpelling(kind);
-end;
-
 constructor TTokenList.Create(const tokenArrayPointer: TTokenArrayPointer);
 begin
   self.tokenArrayPointer := tokenArrayPointer;
@@ -423,6 +435,12 @@ begin
 
 end;
 
+function TToken.GetSpelling: TString;
+begin
+  Result := GetHumanReadbleTokenSpelling(kind);
+end;
+
+
 function TTokenList.GetTokenSpellingAtIndex(const tokenIndex: TTokenIndex): TString;
 var
   kind: TTokenKind;
@@ -434,6 +452,47 @@ begin
     kind := tokenArrayPointer^[tokenIndex].Kind;
     GetHumanReadbleTokenSpelling(kind);
   end;
+end;
+
+
+constructor TUnitList.Create();
+var
+  i: Integer;
+begin
+
+  for i := 1 to MAXUNITS + MAXUNITS do
+  begin
+    UnitArray[i] := TUnit.Create;
+  end;
+end;
+
+destructor TUnitList.Free;
+begin
+end;
+
+function TUnitList.Size: Integer;
+begin
+  Result := Count;
+end;
+
+
+function TUnitList.AddUnit(Name: TUnitName; Path: TFilePath): TUnit;
+var
+  i: Integer;
+begin
+  Result := TUnit.Create;
+
+  // if NumTok > MAXUnitS then
+  //    Error(NumTok, 'Out of resources, TOK');
+  Inc(count);
+
+  // Result.UnitIndex := i;
+  Result.Name := Name;
+  Result.Path := Path;
+
+  unitArray[count]:=Result;
+
+  // WriteLn('Added Unit at index ' + IntToStr(i) + ': ' + );
 end;
 
 procedure SetModifierBit(const modifierCode: TModifierCode; var bits: TModifierBits);

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -179,7 +179,10 @@ type
   TUnitName = TName;
   TUnitIndex = Smallint;
 
+  TSourceFileType = (PROGRAM_FILE, UNIT_FILE, INCLUDE_FILE);
+
   TUnit = class
+    SourceFileType: TSourceFileType;
     Name: TUnitName;
     Path: TFilePath;
     Units: Integer;
@@ -194,7 +197,7 @@ type
     destructor Free;
 
     function Size: Integer;
-    function AddUnit(Name: TUnitName; Path: TFilePath): TUnit;
+    function AddUnit(SourceFileType: TSourceFileType; Name: TUnitName; Path: TFilePath): TUnit;
 
   var
     unitArray: array [1..MAXUNITS + MAXUNITS] of TUnit;  // {$include ...} -> UnitName[MAXUNITS..]
@@ -476,7 +479,7 @@ begin
 end;
 
 
-function TUnitList.AddUnit(Name: TUnitName; Path: TFilePath): TUnit;
+function TUnitList.AddUnit(SourceFileType: TSourceFileType; Name: TUnitName; Path: TFilePath): TUnit;
 var
   i: Integer;
 begin
@@ -487,6 +490,7 @@ begin
   Inc(count);
 
   // Result.UnitIndex := i;
+  Result.SourceFileType:=SourceFileType;
   Result.Name := Name;
   Result.Path := Path;
 

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -215,8 +215,6 @@ type
   end;
 
   // A token list owns token instances.
-
-
   TTokenList = class
   public
   type TTokenArray = array of TToken;

--- a/src/CompilerTypes.pas
+++ b/src/CompilerTypes.pas
@@ -508,31 +508,6 @@ begin
 end;
 
 
-function isIdentifierNameValid(const identifier: TIdentifierName): Boolean;
-const
-  ALLOWED_START_CHARACTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_';
-const
-  ALLOWED_CHARACTERS = ALLOWED_START_CHARACTERS + '0123456789';
-var
-  i: Integer;
-begin
-  if Length(identifier) > 0 then
-    if pos(identifier[1], ALLOWED_START_CHARACTERS) > 0 then
-    begin
-      Result := True;
-      for i := 2 to Length(identifier) do
-      begin
-        if pos(identifier[i], ALLOWED_CHARACTERS) > 0 then
-        begin
-          Result := False;
-          exit;
-        end;
-      end;
-
-    end;
-
-end;
-
 function TUnitList.AddUnit(SourceFileType: TSourceFileType; Name: TUnitName; Path: TFilePath): TUnit;
 
 begin

--- a/src/Diagnostic.pas
+++ b/src/Diagnostic.pas
@@ -39,7 +39,7 @@ begin
   for i := 1 to NumTok do
   begin
     // DiagFile.Write(i: 6, GetUnitName(Tok[i].UnitIndex) 30, Tok[i].Line: 6, GetSpelling(i): 30);
-    DiagFile.Write(i, 6).Write(GetUnitName(Tok[i].UnitIndex), 30).Write(Tok[i].Line,
+    DiagFile.Write(i, 6).Write(Tok[i].SourceCodeFile.Name, 30).Write(Tok[i].Line,
       6).Write(tokenList.GetTokenSpellingAtIndex(i), 30).WriteLn;
     if Tok[i].Kind = TTokenKind.INTNUMBERTOK then
       DiagFile.WriteLn(' = ', IntToStr(Tok[i].Value))

--- a/src/Diagnostic.pas
+++ b/src/Diagnostic.pas
@@ -38,7 +38,7 @@ begin
 
   for i := 1 to NumTok do
   begin
-    // DiagFile.Write(i: 6, GetUnitName(Tok[i].UnitIndex) 30, Tok[i].Line: 6, GetSpelling(i): 30);
+    // DiagFile.Write(i: 6, Tok[i].SourceCodeFile.UnitIndex) 30, Tok[i].Line: 6, GetSpelling(i): 30);
     DiagFile.Write(i, 6).Write(Tok[i].SourceCodeFile.Name, 30).Write(Tok[i].Line,
       6).Write(tokenList.GetTokenSpellingAtIndex(i), 30).WriteLn;
     if Tok[i].Kind = TTokenKind.INTNUMBERTOK then

--- a/src/FileIO.pas
+++ b/src/FileIO.pas
@@ -249,7 +249,7 @@ begin
 
   for i := Low(paths) to High(paths) do
   begin
-    Result := paths[i] + filePath;
+    Result := TFileSystem.NormalizePath(paths[i] + filePath);
     if TFileSystem.FileExists_(Result) then Exit;
   end;
   Result := '';

--- a/src/Makefile.bat
+++ b/src/Makefile.bat
@@ -163,7 +163,7 @@ rem Run all tests with a given mp.exe.
 rem IN: Path to mp.exe
 rem
 :run_tests
-  call :run_mp %1 %MP_TESTS_FOLDER% Test-MP
+  call :run_mp %1 %MP_TESTS_FOLDER% TestMP
   
   if "%TEST_MODE%"=="FAST" goto :eof
   call :run_mp %1 %MP_FOLDER%\samples\a8\games\PacMad pacmad

--- a/src/Messages.pas
+++ b/src/Messages.pas
@@ -370,7 +370,7 @@ begin
   for i := fromTokenIndex to toTokenIndex do
   begin
     token := Tok[i];
-    WriteLn(GetUnit(token.UnitIndex).Path + ' ( line ' + IntToStr(token.Line) + ', column ' +
+    WriteLn(token.SourceCodeFile.Path + ' ( line ' + IntToStr(token.Line) + ', column ' +
       IntToStr(token.Column) + '): kind=' + GetTokenKindName(token.Kind) + ' name=' + token.Name + '.');
   end;
 end;
@@ -418,12 +418,12 @@ begin
       if (effectiveTokenIndex > 1) then
       begin
         previousToken := Tok[effectiveTokenIndex - 1];
-        WriteLn(GetUnit(token.UnitIndex).Path + ' (' + IntToStr(token.Line) + ',' +
+        WriteLn(token.SourceCodeFile.Path + ' (' + IntToStr(token.Line) + ',' +
           IntToStr(Succ(previousToken.Column)) + ')' + ' Error: ' + msg);
       end
       else
       begin
-        WriteLn(GetUnit(token.UnitIndex).Path + ' (' + IntToStr(token.Line) + ')' + ' Error: ' + msg);
+        WriteLn(token.SourceCodeFile.Path + ' (' + IntToStr(token.Line) + ')' + ' Error: ' + msg);
       end;
     end
     else
@@ -638,7 +638,7 @@ begin
   if pass = TPass.CODE_GENERATION then
   begin
 
-    a := GetUnit(Tok[tokenIndex].UnitIndex).Path + ' (' + IntToStr(Tok[tokenIndex].Line) +
+    a := Tok[tokenIndex].SourceCodeFile.Path + ' (' + IntToStr(Tok[tokenIndex].Line) +
       ')' + ' Warning: ' + msg.GetText();
 
     // Add warning only once.
@@ -714,7 +714,7 @@ begin
     if pos('.', Ident[identIndex].Name) = 0 then
     begin
 
-      a := GetUnit(Tok[tokenIndex].UnitIndex).Path + ' (' + IntToStr(Tok[tokenIndex].Line) +
+      a := Tok[tokenIndex].SourceCodeFile.Path + ' (' + IntToStr(Tok[tokenIndex].Line) +
         ')' + ' Note: Local ';
 
       if Ident[identIndex].Kind <> UNITTYPE then
@@ -760,7 +760,7 @@ begin
   if Pass = TPass.CODE_GENERATION then
   begin
 
-    a := GetUnit(Tok[tokenIndex].UnitIndex).Path + ' (' + IntToStr(Tok[tokenIndex].Line) + ')' + ' Note: ';
+    a := Tok[tokenIndex].SourceCodeFile.Path + ' (' + IntToStr(Tok[tokenIndex].Line) + ')' + ' Note: ';
     a := a + msg;
 
     msgLists.msgNote.Add(a);

--- a/src/Messages.pas
+++ b/src/Messages.pas
@@ -185,20 +185,6 @@ end;
 
 // ----------------------------------------------------------------------------
 
-procedure AddMessage(var msg: TStringArray; const a: String);
-var
-  i: Integer;
-begin
-
-  i := High(msg);
-  msg[i] := a;
-
-  SetLength(msg, i + 2);
-
-end;
-
-// ----------------------------------------------------------------------------
-
 procedure WritelnMsg;
 var
   i: Integer;
@@ -640,7 +626,6 @@ end;
 
 procedure Warning(const tokenIndex: TTokenIndex; const msg: IMessage);
 var
-  i: Integer;
   a: String;
 begin
 

--- a/src/Messages.pas
+++ b/src/Messages.pas
@@ -206,11 +206,11 @@ begin
 
   TextColor(LIGHTGREEN);
 
-  for i := 0 to High(msgWarning) - 1 do writeln(msgWarning[i]);
+  for i := 0 to msgLists.msgWarning.Count - 1 do writeln(msgLists.msgWarning[i]);
 
   TextColor(LIGHTCYAN);
 
-  for i := 0 to High(msgNote) - 1 do writeln(msgNote[i]);
+  for i := 0 to msgLists.msgNote.Count - 1 do writeln(msgLists.msgNote[i]);
 
   NormVideo;
 
@@ -243,7 +243,7 @@ end;
 
 function GetUserDefinedText(const tokenIndex: TTokenIndex): String;
 begin
-  Result := 'User defined: ' + msgUser[Tok[tokenIndex].Value];
+  Result := 'User defined: ' + msgLists.msgUser[Tok[tokenIndex].Value];
 end;
 
 function GetErrorMessage(const tokenIndex: TTokenIndex; const errorCode: TErrorCode;
@@ -650,14 +650,8 @@ begin
     a := GetUnit(Tok[tokenIndex].UnitIndex).Path + ' (' + IntToStr(Tok[tokenIndex].Line) +
       ')' + ' Warning: ' + msg.GetText();
 
-    for i := High(msgWarning) - 1 downto 0 do
-    begin
-      if msgWarning[i] = a then exit;
-    end;
-
-    i := High(msgWarning);
-    msgWarning[i] := a;
-    SetLength(msgWarning, i + 2);
+    // Add warning only once.
+    if msgLists.msgWarning.IndexOf(a) < 0 then  msgLists.msgWarning.Add(a);
 
   end;
 
@@ -754,7 +748,7 @@ begin
         if pos('@FN', Ident[identIndex].Name) = 1 then
 
         else
-          AddMessage(msgNote, a);
+          msgLists.msgNote.Add(a);
 
       end;
 
@@ -778,7 +772,7 @@ begin
     a := GetUnit(Tok[tokenIndex].UnitIndex).Path + ' (' + IntToStr(Tok[tokenIndex].Line) + ')' + ' Note: ';
     a := a + msg;
 
-    AddMessage(msgNote, a);
+    msgLists.msgNote.Add(a);
 
   end;
 

--- a/src/Messages.pas
+++ b/src/Messages.pas
@@ -70,6 +70,7 @@ type
 
 // ----------------------------------------------------------------------------
 
+procedure Initialize;
 
 procedure Error(const tokenIndex: TTokenIndex; const msg: String); overload;
 procedure Error(const tokenIndex: TTokenIndex; const msg: IMessage); overload;
@@ -119,7 +120,7 @@ procedure WritelnMsg;
 
 implementation
 
-uses SysUtils, TypInfo, Console, Utilities;
+uses Classes, SysUtils, TypInfo, Console, Utilities;
 
 // -----------------------------------------------------------------------------
 constructor TMessage.Create(const errorCode: TErrorCode; const Text: String; const variable0: String = '';
@@ -184,6 +185,13 @@ begin
 end;
 
 // ----------------------------------------------------------------------------
+
+procedure Initialize;
+begin
+  msgLists.msgUser := TStringList.Create;
+  msgLists.msgWarning := TStringList.Create;
+  msgLists.msgNote := TStringList.Create;
+end;
 
 procedure WritelnMsg;
 var
@@ -394,8 +402,6 @@ begin
   begin
 
     //Tok[NumTok-1].Column := Tok[NumTok].Column + Tok[NumTok-1].Column;
-
-    WritelnMsg;  // TODO: Required?
 
     if tokenIndex <= NumTok then effectiveTokenIndex := tokenIndex
     else

--- a/src/Optimize.pas
+++ b/src/Optimize.pas
@@ -3733,7 +3733,7 @@ begin        // OptimizeASM
     if common.optimize.line <> common.optimize.old then
     begin
       WriteOut('');
-      WriteOut('; optimize OK (' + common.optimize.SourceCodeFile.Name + ', line = ' +
+      WriteOut('; optimize OK (' + common.optimize.SourceCodeFile.Name + '), line = ' +
         IntToStr(common.optimize.line));
       WriteOut('');
 

--- a/src/Optimize.pas
+++ b/src/Optimize.pas
@@ -3818,10 +3818,10 @@ begin        // OptimizeASM
       WriteOut('');
 
       if x = 51 then
-        WriteOut('; optimize FAIL (' + '''' + arg0 + '''' + ', ' + GetUnit(common.optimize.unitIndex).Name +
+        WriteOut('; optimize FAIL (' + '''' + arg0 + '''' + ', ' + GetUnitName(common.optimize.unitIndex) +
           '), line = ' + IntToStr(common.optimize.line))
       else
-        WriteOut('; optimize FAIL (' + IntToStr(x) + ', ' + GetUnit(common.optimize.unitIndex).Name +
+        WriteOut('; optimize FAIL (' + IntToStr(x) + ', ' + GetUnitName(common.optimize.unitIndex) +
           '), line = ' + IntToStr(common.optimize.line));
 
       WriteOut('');

--- a/src/Optimize.pas
+++ b/src/Optimize.pas
@@ -618,7 +618,7 @@ var
 
       TextColor(LIGHTRED);
 
-      WriteLn(GetUnit(common.optimize.unitIndex).Path + ' (' + IntToStr(common.optimize.line) +
+      WriteLn(common.optimize.SourceCodeFile.Path + ' (' + IntToStr(common.optimize.line) +
         ') Error: Illegal instruction in INTERRUPT block ''' + copy(listing[i], 2, 256) + '''');
 
       NormVideo;
@@ -3422,88 +3422,129 @@ begin        // OptimizeASM
                                                                                                   // @SHORTREAL_MUL  accepted
                                                                                                   else
                                                                                                     if elf =
-                                                                                                      $096287FC then    // @REAL_MUL    accepted
+                                                                                                      $096287FC then
+                                                                                                    // @REAL_MUL    accepted
                                                                                                     else
                                                                                                       if elf =
-                                                                                                        $0E9645D6 then    // @SHORTREAL_DIV  accepted
+                                                                                                        $0E9645D6 then
+                                                                                                      // @SHORTREAL_DIV  accepted
                                                                                                       else
                                                                                                         if elf =
-                                                                                                          $09627D86 then    // @REAL_DIV    accepted
+                                                                                                          $09627D86 then
+                                                                                                        // @REAL_DIV    accepted
                                                                                                         else
 
                                                                                                           if elf =
-                                                                                                            $02042144 then    // @REAL_ROUND    accepted
+                                                                                                            $02042144 then
+                                                                                                          // @REAL_ROUND    accepted
                                                                                                           else
                                                                                                             if elf =
-                                                                                                              $063448B3 then    // @SHORTREAL_TRUNC  accepted
+                                                                                                              $063448B3 then
+                                                                                                            // @SHORTREAL_TRUNC  accepted
                                                                                                             else
                                                                                                               if elf =
-                                                                                                                $020C1143 then    // @REAL_TRUNC    accepted
+                                                                                                                $020C1143
+                                                                                                              then    // @REAL_TRUNC    accepted
                                                                                                               else
                                                                                                                 if
-                                                                                                                elf = $0627E0C3 then    // @REAL_FRAC    accepted
+                                                                                                                elf =
+                                                                                                                  $0627E0C3 then    // @REAL_FRAC    accepted
                                                                                                                 else
 
                                                                                                                   if elf
-                                                                                                                    = $0044B29C then    // @FMUL    accepted
+                                                                                                                    =
+                                                                                                                    $0044B29C
+                                                                                                                  then    // @FMUL    accepted
                                                                                                                   else
                                                                                                                     if elf
-                                                                                                                      = $0044A8E6 then    // @FDIV    accepted
+                                                                                                                      =
+                                                                                                                      $0044A8E6 then    // @FDIV    accepted
                                                                                                                     else
                                                                                                                       if
-                                                                                                                      elf = $0044A584 then    // @FADD    accepted
+                                                                                                                      elf
+                                                                                                                        = $0044A584 then    // @FADD    accepted
                                                                                                                       else
                                                                                                                         if
-                                                                                                                        elf = $0044B892 then    // @FSUB    accepted
+                                                                                                                        elf
+                                                                                                                          = $0044B892 then    // @FSUB    accepted
                                                                                                                         else
                                                                                                                           if
-                                                                                                                          elf = $00044C66 then    // @I2F      accepted
+                                                                                                                          elf
+                                                                                                                            = $00044C66 then    // @I2F      accepted
                                                                                                                           else
                                                                                                                             if
-                                                                                                                            elf = $00044969 then    // @F2I      accepted
+                                                                                                                            elf
+                                                                                                                              = $00044969 then    // @F2I      accepted
                                                                                                                             else
                                                                                                                               if
-                                                                                                                              elf = $044AB653 then    // @FFRAC    accepted
+                                                                                                                              elf
+                                                                                                                                = $044AB653 then    // @FFRAC    accepted
                                                                                                                               else
                                                                                                                                 if
-                                                                                                                                elf = $04B74A64 then    // @FROUND    accepted
+                                                                                                                                elf
+                                                                                                                                  =
+                                                                                                                                  $04B74A64 then    // @FROUND    accepted
                                                                                                                                 else
 
                                                                                                                                   if
-                                                                                                                                  elf = $094C3D21 then    // @F16_F2A    accepted
+                                                                                                                                  elf
+                                                                                                                                    =
+                                                                                                                                    $094C3D21 then    // @F16_F2A    accepted
                                                                                                                                   else
                                                                                                                                     if
-                                                                                                                                    elf = $094C31C4 then    // @F16_ADD    accepted
+                                                                                                                                    elf
+                                                                                                                                      =
+                                                                                                                                      $094C31C4 then    // @F16_ADD    accepted
                                                                                                                                     else
                                                                                                                                       if
-                                                                                                                                      elf = $094C4CD2 then     // @F16_SUB    accepted
+                                                                                                                                      elf
+                                                                                                                                        =
+                                                                                                                                        $094C4CD2 then     // @F16_SUB    accepted
                                                                                                                                       else
                                                                                                                                         if
-                                                                                                                                        elf = $094C46DC then    // @F16_MUL    accepted
+                                                                                                                                        elf
+                                                                                                                                          =
+                                                                                                                                          $094C46DC then    // @F16_MUL    accepted
                                                                                                                                         else
                                                                                                                                           if
-                                                                                                                                          elf = $094C3CA6 then    // @F16_DIV    accepted
+                                                                                                                                          elf
+                                                                                                                                            =
+                                                                                                                                            $094C3CA6 then    // @F16_DIV    accepted
                                                                                                                                           else
                                                                                                                                             if
-                                                                                                                                            elf = $094C3A74 then    // @F16_INT    accepted
+                                                                                                                                            elf
+                                                                                                                                              =
+                                                                                                                                              $094C3A74 then    // @F16_INT    accepted
                                                                                                                                             else
                                                                                                                                               if
-                                                                                                                                              elf = $0C430164 then    // @F16_ROUND    accepted
+                                                                                                                                              elf
+                                                                                                                                                =
+                                                                                                                                                $0C430164 then    // @F16_ROUND    accepted
                                                                                                                                               else
                                                                                                                                                 if
-                                                                                                                                                elf = $04C3F2C3 then    // @F16_FRAC    accepted
+                                                                                                                                                elf
+                                                                                                                                                  =
+                                                                                                                                                  $04C3F2C3 then    // @F16_FRAC    accepted
                                                                                                                                                 else
                                                                                                                                                   if
-                                                                                                                                                  elf = $094C3826 then    // @F16_I2F    accepted
+                                                                                                                                                  elf
+                                                                                                                                                    =
+                                                                                                                                                    $094C3826 then    // @F16_I2F    accepted
                                                                                                                                                   else
                                                                                                                                                     if
-                                                                                                                                                    elf = $0494C3E1 then    // @F16_EQ    accepted
+                                                                                                                                                    elf
+                                                                                                                                                      =
+                                                                                                                                                      $0494C3E1 then    // @F16_EQ    accepted
                                                                                                                                                     else
                                                                                                                                                       if
-                                                                                                                                                      elf = $0494C384 then    // @F16_GT    accepted
+                                                                                                                                                      elf
+                                                                                                                                                        =
+                                                                                                                                                        $0494C384 then    // @F16_GT    accepted
                                                                                                                                                       else
                                                                                                                                                         if
-                                                                                                                                                        elf = $094C38C5 then    // @F16_GTE    accepted
+                                                                                                                                                        elf
+                                                                                                                                                          =
+                                                                                                                                                          $094C38C5 then    // @F16_GTE    accepted
 
 
                                                                                                                                                         else
@@ -3692,7 +3733,7 @@ begin        // OptimizeASM
     if common.optimize.line <> common.optimize.old then
     begin
       WriteOut('');
-      WriteOut('; optimize OK (' + GetUnit(common.optimize.unitIndex).Name + '), line = ' +
+      WriteOut('; optimize OK (' + common.optimize.SourceCodeFile.Name + ', line = ' +
         IntToStr(common.optimize.line));
       WriteOut('');
 
@@ -3818,10 +3859,10 @@ begin        // OptimizeASM
       WriteOut('');
 
       if x = 51 then
-        WriteOut('; optimize FAIL (' + '''' + arg0 + '''' + ', ' + GetUnitName(common.optimize.unitIndex) +
+        WriteOut('; optimize FAIL (' + '''' + arg0 + '''' + ', ' + common.optimize.SourceCodeFile.Name +
           '), line = ' + IntToStr(common.optimize.line))
       else
-        WriteOut('; optimize FAIL (' + IntToStr(x) + ', ' + GetUnitName(common.optimize.unitIndex) +
+        WriteOut('; optimize FAIL (' + IntToStr(x) + ', ' + common.optimize.SourceCodeFile.Name +
           '), line = ' + IntToStr(common.optimize.line));
 
       WriteOut('');
@@ -3849,7 +3890,7 @@ begin        // OptimizeASM
     Writeln(OptFile, OptimizeBuf[i]);
 
  writeln(OptFile, StringOfChar('-', 32));
- writeln(OptFile, 'OPTIMIZE ',((x = 0) and inxUse),', x=',x,', ('+UnitArray[common.optimize.unitIndex].Name+') line = ',common.optimize.line);
+ writeln(OptFile, 'OPTIMIZE ',((x = 0) and inxUse),', x=',x,', ('+common.optimize.SourceCodeFile.Name+') line = ',common.optimize.line);
  writeln(OptFile, StringOfChar('-', 32));
 
   for i := 0 to l - 1 do

--- a/src/Parser.pas
+++ b/src/Parser.pas
@@ -106,7 +106,7 @@ var
             if pos('.', X) > 0 then GetIdentIndex(copy(X, 1, pos('.', X) - 1));
 
             if (Ident[IdentIndex].UnitIndex = UnitIndex) or (Ident[IdentIndex].UnitIndex = 1)
-            { or (UnitArray[Ident[IdentIndex].UnitIndex].Name = 'SYSTEM')} then exit;
+            { or (GetUnitNane[Ident[IdentIndex].UnitIndex) = 'SYSTEM')} then exit;
           end;
 
   end;

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -273,24 +273,23 @@ var
         // We clear earlier usage
         for j := 2 to NumUnits do
         begin
-          if UnitArray[j].Name = s then UnitArray[j].Name := '';
+          if GetUnitName(j) = s then UnitList.UnitArray[j].Name := '';
         end;
 
         _line := Line;
         _uidx := UnitIndex;
 
-        Inc(NumUnits);
-        UnitIndex := NumUnits;
+        // TODO
+        UnitIndex := NumUnits+1;
 
-        if UnitIndex > High(UnitArray) then
+        if UnitIndex > High(UnitList.UnitArray) then
         begin
           Error(NumTok, TMessage.Create(TErrorCode.OutOfResources, 'Out of resources, UnitIndex: ' +
             IntToStr(UnitIndex)));
         end;
 
         Line := 1;
-        UnitArray[UnitIndex].Name := s;
-        UnitArray[UnitIndex].Path := nam;
+        UnitList.AddUnit(s,nam);
 
         TokenizeUnit(UnitIndex, True);
 
@@ -569,12 +568,12 @@ var
                               _uidx := UnitIndex;
 
                               Line := 1;
-                              UnitArray[IncludeIndex].Name := ExtractFileName(nam);
-                              UnitArray[IncludeIndex].Path := nam;
+                              UnitList.UnitArray[IncludeIndex].Name := ExtractFileName(nam);
+                              UnitList.UnitArray[IncludeIndex].Path := nam;
                               UnitIndex := IncludeIndex;
                               Inc(IncludeIndex);
 
-                              if IncludeIndex > High(UnitArray) then
+                              if IncludeIndex > High(UnitList.UnitArray) then
                                 Error(NumTok, TMessage.Create(TErrorCode.OutOfResources,
                                   'Out of resources, IncludeIndex: ' + IntToStr(IncludeIndex)));
 
@@ -1798,7 +1797,7 @@ var
 
     UnitFound := False;
 
-    Tokenize(UnitArray[UnitIndex].Path, testUnit);
+    Tokenize(UnitList.UnitArray[UnitIndex].Path, testUnit);
 
     if UnitIndex > 1 then
     begin

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -280,7 +280,7 @@ var
         _uidx := UnitIndex;
 
         // TODO
-        UnitIndex := NumUnits+1;
+        UnitIndex := NumUnits + 1;
 
         if UnitIndex > High(UnitList.UnitArray) then
         begin
@@ -289,7 +289,7 @@ var
         end;
 
         Line := 1;
-        UnitList.AddUnit(s,nam);
+        UnitList.AddUnit(TSourceFileType.UNIT_FILE, s, nam);
 
         TokenizeUnit(UnitIndex, True);
 
@@ -475,7 +475,7 @@ var
 
         SkipWhitespaces(d, i);
 
-        msgLists.msgUser.Add( copy(d, i, length(d) - i));
+        msgLists.msgUser.Add(copy(d, i, length(d) - i));
 
       end;
 

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -30,7 +30,7 @@ type
 
 implementation
 
-uses SysUtils, Common, Datatypes, Messages, FileIO, Memory, Optimize, StringUtilities, Targets, Utilities;
+uses Classes, SysUtils, Common, Datatypes, Messages, FileIO, Memory, Optimize, StringUtilities, Targets, Utilities;
 
 // ----------------------------------------------------------------------------
 // Class TScanner Implementation
@@ -60,13 +60,13 @@ begin
   DataSegmentUse := False;
   LoopUnroll := False;
   PublicSection := True;
-  UnitNameIndex := 1;
+  UnitNameIndex := 1; // TODO This is the current unit index
 
   SetLength(linkObj, 1);
   SetLength(resArray, 1);
-  SetLength(msgUser, 1);
-  SetLength(msgWarning, 1);
-  SetLength(msgNote, 1);
+  msgLists.msgUser := TStringList.Create;
+  msgLists.msgWarning := TStringList.Create;
+  msgLists.msgNote := TStringList.Create;
 
   NumBlocks := 0;
   BlockStackTop := 0;
@@ -469,15 +469,14 @@ var
         k: Integer;
       begin
 
-        k := High(msgUser);
+        k := msgLists.msgUser.Count;
 
         AddToken(Kind, UnitIndex, Line, 1, k);
         AddToken(TTokenKind.SEMICOLONTOK, UnitIndex, Line, 1, 0);
 
         SkipWhitespaces(d, i);
 
-        msgUser[k] := copy(d, i, length(d) - i);
-        SetLength(msgUser, k + 2);
+        msgLists.msgUser.Add( copy(d, i, length(d) - i));
 
       end;
 

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -14,7 +14,7 @@ type
     procedure TokenizeProgram(UsesOn: Boolean);
 
     // This is only public for for testing. Idea: Put token array into a ITokenList, so it can be tested independently of the whole scanner
-    procedure AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger);
+    procedure AddToken(Kind: TTokenKind; UnitIndex: TUnitIndex; Line, Column: Integer; Value: TInteger);
 
   end;
 
@@ -22,7 +22,7 @@ type
   TScanner = class(TInterfacedObject, IScanner)
 
     procedure TokenizeProgram(UsesOn: Boolean);
-    procedure AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger);
+    procedure AddToken(Kind: TTokenKind; UnitIndex: TUnitIndex; Line, Column: Integer; Value: TInteger);
 
   private
     procedure TokenizeMacro(a: String; Line, Spaces: Integer);
@@ -179,7 +179,7 @@ end;  //AddResource
 // ----------------------------------------------------------------------------
 
 
-procedure TScanner.AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger);
+procedure TScanner.AddToken(Kind: TTokenKind; UnitIndex: TUnitIndex; Line, Column: Integer; Value: TInteger);
 begin
   tokenList.AddToken(kind, unitList.GetUnit(UnitIndex), line, Column, Value);
 end;
@@ -275,7 +275,7 @@ var
         // This means this entry in the unit list will not be tokenized.
         for j := 2 to NumUnits do
         begin
-          if GetUnitName(j) = s then UnitList.GetUnit(j).Name := '';
+          if UnitList.GetUnit(j).Name = s then UnitList.GetUnit(j).Name := '';
         end;
 
         _line := Line;

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -181,7 +181,7 @@ end;  //AddResource
 
 procedure TScanner.AddToken(Kind: TTokenKind; UnitIndex, Line, Column: Integer; Value: TInteger);
 begin
-  tokenList.AddToken(kind, UnitIndex, line, Column, Value);
+  tokenList.AddToken(kind, unitList.GetUnit(UnitIndex), line, Column, Value);
 end;
 
 

--- a/src/TestUnits.pas
+++ b/src/TestUnits.pas
@@ -136,7 +136,10 @@ uses
   procedure TestUnitCommon;
   var
     filePath: TFilePath;
+    unitList: TUnitList;
+    sourceCodeFile: Tunit;
     tokenList: TTokenList;
+    token: TToken;
   begin
 
     StartTest('TestUnitCommon');
@@ -151,10 +154,15 @@ uses
     // Unit Scanner
     Program_NAME := 'TestProgram';
 
+    unitList := TUnitList.Create();
+    sourceCodeFile := unitList.AddUnit(TSourceFileType.PROGRAM_FILE, 'TEST_PROGRAM', 'TestProgram.pas');
     tokenList := TTokenList.Create(Addr(tok));
     // Kind, UnitIndex, Line, Column, Value
-    tokenList.AddToken(TTokenKind.PROGRAMTOK, 1, 1, 1, 0);
+    token := tokenList.AddToken(TTokenKind.PROGRAMTOK, sourceCodeFile, 1, 1, 0);
+    tokenList.Free;
     tokenList := nil;
+    unitList.Free;
+    unitList := nil;
 
     // Unit Common
     unitPathList := TPathList.Create;

--- a/src/TestUnits.pas
+++ b/src/TestUnits.pas
@@ -104,14 +104,14 @@ uses
     EndTest('TestFileIO');
   end;
 
-  procedure TestUnitFile;
+  procedure TestUnitFileIO;
   const
     TEST_MP_FILE_PATH = '..\src\tests\TestMP.pas';
   var
     pathList: TPathList;
 
   begin
-    StartTest('TestUnitFile');
+    StartTest('TestUnitFileIO');
     TestNative(TEST_MP_FILE_PATH);
     TestFileIO(TEST_MP_FILE_PATH);
 
@@ -123,7 +123,14 @@ uses
     Assert(pathList.ToString() = 'Folder1' + TFileSystem.PathDelim + ';Folder2' + TFileSystem.PathDelim);
     pathList.Free;
 
-    EndTest('TestUnitFile');
+    AssertEquals(SysUtils.ExtractFileName(''), '');
+    AssertEquals(SysUtils.ExtractFileName('ABC.'), 'ABC.');
+    AssertEquals(SysUtils.ExtractFileName('ABC.xyz'), 'ABC.xyz');
+    AssertEquals(SysUtils.ExtractFileName('/a/b/ABC.xyz'), 'ABC.xyz');
+    AssertEquals(SysUtils.ExtractFileName('\a\b\ABC.xyz'), 'ABC.xyz');
+    AssertEquals(SysUtils.ExtractFileName('\a\b\c/d/ABC.xyz'), 'ABC.xyz');
+
+    EndTest('TestUnitFileIO');
   end;
 
   procedure TestUnitCommon;
@@ -308,7 +315,7 @@ type
 
 begin
   try
-    TestUnitFile;
+    TestUnitFileIO;
     TestUnitCommon;
     TestUnitDatatypes;
     TestUnitMathEvaluate;

--- a/src/TestUnits.pas
+++ b/src/TestUnits.pas
@@ -106,7 +106,7 @@ uses
 
   procedure TestUnitFile;
   const
-    TEST_MP_FILE_PATH = '..\src\tests\Test-MP.pas';
+    TEST_MP_FILE_PATH = '..\src\tests\TestMP.pas';
   var
     pathList: TPathList;
 
@@ -281,9 +281,11 @@ type
   begin
 
     StartTest('TestUnitMessages');
+    Messages.Initialize;
     message := TMessage.Create(TErrorCode.IllegalExpression,
       'A={0} B={1} C={2} D={3} E={4} F={5} G={6} H={7} I={8} J={9}', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J');
     AssertEquals(message.GetText(), 'A=A B=B C=C D=D E=E F=F G=G H=H I=I J=J');
+    Messages.WritelnMsg;
     EndTest('TestUnitMessages');
   end;
 

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -478,7 +478,7 @@ uses
     if (TEnvironment.GetParameterCount = 0) then Syntax(THaltException.COMPILING_NOT_STARTED);
 
     UnitList:=TUnitList.Create();
-    UnitList.AddUnit('', '');
+    UnitList.AddUnit(TSourceFileType.PROGRAM_FILE,'', '');
 
     try
       ParseParam();

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -188,9 +188,9 @@ uses
   SysUtils,
  {$IFDEF WINDOWS}
   Windows,
-                        {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
+                           {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
   browserconsole,
-                        {$ENDIF}
+                           {$ENDIF}
   Common,
   Compiler,
   CompilerTypes,
@@ -223,6 +223,7 @@ uses
     MainPath: String;
 
     // Command line parameters
+    programUnit: TUnit;
     unitPathList: TPathList;
     targetID: TTargetID;
     cpu: TCPU;
@@ -239,6 +240,7 @@ uses
       parameter, parameterUpperCase, parameterValue: String;
     begin
 
+      programUnit := GetUnit(1);
       targetID := TTargetID.A8;
       cpu := TCPU.NONE;
 
@@ -413,10 +415,10 @@ uses
         else
 
         begin
-          UnitList.UnitArray[NumUnits].Name := TEnvironment.GetParameterString(i);
-          UnitList.UnitArray[NumUnits].Path := UnitList.UnitArray[NumUnits].Name;
+          programUnit.Path := TFileSystem.NormalizePath(TEnvironment.GetParameterString(i));
+          programUnit.Name := ExtractFileName(programUnit.Path);
 
-          if not TFileSystem.FileExists_(GetUnit(NumUnits).Path) then
+          if not TFileSystem.FileExists_(programUnit.Path) then
           begin
             writeln('Error: Can''t open file ''' + GetUnit(NumUnits).Path + '''.');
             RaiseHaltException(THaltException.COMPILING_NOT_STARTED);
@@ -477,8 +479,8 @@ uses
 
     if (TEnvironment.GetParameterCount = 0) then Syntax(THaltException.COMPILING_NOT_STARTED);
 
-    UnitList:=TUnitList.Create();
-    UnitList.AddUnit(TSourceFileType.PROGRAM_FILE,'', '');
+    UnitList := TUnitList.Create();
+    UnitList.AddUnit(TSourceFileType.PROGRAM_FILE, '', '');
 
     try
       ParseParam();

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -413,8 +413,8 @@ uses
         else
 
         begin
-          UnitArray[NumUnits].Name := TEnvironment.GetParameterString(i);
-          UnitArray[NumUnits].Path := UnitArray[NumUnits].Name;
+          UnitList.UnitArray[NumUnits].Name := TEnvironment.GetParameterString(i);
+          UnitList.UnitArray[NumUnits].Path := UnitList.UnitArray[NumUnits].Name;
 
           if not TFileSystem.FileExists_(GetUnit(NumUnits).Path) then
           begin
@@ -477,8 +477,9 @@ uses
 
     if (TEnvironment.GetParameterCount = 0) then Syntax(THaltException.COMPILING_NOT_STARTED);
 
-    NumUnits := 1;           // !!! 1 !!!
-    UnitArray[NumUnits].Name := '';
+    UnitList:=TUnitList.Create();
+    UnitList.AddUnit('', '');
+
     try
       ParseParam();
     except
@@ -590,7 +591,7 @@ var
 begin
   exitCode := CallMain;
   {$IFDEF DEBUG}
-  exitCode := CallMain; // TODO until 2nd call works
+  //exitCode := CallMain; // TODO until 2nd call works
   {$ENDIF}
 
     {$IFDEF DEBUG}

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -188,9 +188,9 @@ uses
   SysUtils,
  {$IFDEF WINDOWS}
   Windows,
-                       {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
+                        {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
   browserconsole,
-                       {$ENDIF}
+                        {$ENDIF}
   Common,
   Compiler,
   CompilerTypes,
@@ -442,7 +442,7 @@ uses
         target.zpage := ZPAGE_BASE;
 
 
-      if cpu <>TCPU.NONE then target.cpu := cpu;
+      if cpu <> TCPU.NONE then target.cpu := cpu;
 
       case target.cpu of
         TCPU.CPU_6502: AddDefine('CPU_6502');
@@ -550,8 +550,8 @@ uses
 
     TextColor(LIGHTGRAY);
 
-    if High(msgWarning) > 0 then Writeln(IntToStr(High(msgWarning)) + ' warning(s) issued');
-    if High(msgNote) > 0 then Writeln(IntToStr(High(msgNote)) + ' note(s) issued');
+    if msgLists.msgWarning.Count > 0 then Writeln(IntToStr(msgLists.msgWarning.Count) + ' warning(s) issued');
+    if msgLists.msgNote.Count > 0 then Writeln(IntToStr(msgLists.msgNote.Count) + ' note(s) issued');
 
     NormVideo;
   end;

--- a/src/mp.pas
+++ b/src/mp.pas
@@ -188,9 +188,9 @@ uses
   SysUtils,
  {$IFDEF WINDOWS}
   Windows,
-                               {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
+                                {$ENDIF} {$IFDEF SIMULATED_CONSOLE}
   browserconsole,
-                               {$ENDIF}
+                                {$ENDIF}
   Common,
   Compiler,
   CompilerTypes,
@@ -500,7 +500,7 @@ uses
 
  {$IFDEF USEOPTFILE}
 
-   OptFile.AssignFile(ChangeFileExt(GetUnitName(NumUnits), '.opt') ); OptFile.Rewrite();
+   OptFile.AssignFile(ChangeFileExt(programUnit.Name, '.opt') ); OptFile.Rewrite();
 
  {$ENDIF}
 

--- a/src/tests/TestInclude.inc
+++ b/src/tests/TestInclude.inc
@@ -1,0 +1,7 @@
+const TestIncludeString : String = 'TestIncludeString';
+
+function TestIncludeFunction: String;
+begin
+  Result:=TestIncludeString;
+end;
+

--- a/src/tests/TestMP.pas
+++ b/src/tests/TestMP.pas
@@ -2,10 +2,12 @@
 //
 // Ensure that the new Mad-Pascal Version compiles correctly to .a65
 
-program test;
+program TestMP;
 
 uses
-  Crt;
+  Crt, TestUnit;
+
+{$I TestInclude.inc}
 
   procedure Assert(b: Boolean; s: String); overload;
   begin
@@ -68,6 +70,8 @@ var
 begin
   TestExpressions;
   TestFloats;
+  AssertEquals(TestUnit.TestUnitFunction, TestUnit.TestUnitString);
+  AssertEquals(TestIncludeString, TestIncludeString);
 
   Writeln('Test completed. Press any key');
   repeat

--- a/src/tests/TestUnit.pas
+++ b/src/tests/TestUnit.pas
@@ -1,0 +1,16 @@
+unit TestUnit;
+
+interface
+
+const TestUnitString = 'TestUnitString';
+
+function TestUnitFunction: String;
+
+implementation
+
+function TestUnitFunction: String;
+begin
+  Result:=TestUnitString;
+end;
+
+end.


### PR DESCRIPTION
This way, tokens (and, in the next step, identifiers) can have a direct reference to their owning unit instead of relying on an index. Also, these commits contain the generalization of TUnit to a source file of type PROGRAM_FILE/UNIT_FILE/INCLUDE_FILE. This replaces the double-sized UnitArray with two distinct index ranges: 1..MAX for units and MAX+1..2*MAX for includes.