### PR TITLE
Fix for Linux path issue

### DIFF
--- a/src/FileIO.pas
+++ b/src/FileIO.pas
@@ -711,8 +711,6 @@ begin
    begin
     Result := StringReplace(filePath, '\', '/', [rfReplaceAll]);
    end;
-
-  Result := LowerCase(Result);
   {$ENDIF}
 
   {$IFDEF SIMULATED_FILE_IO}

--- a/src/Scanner.pas
+++ b/src/Scanner.pas
@@ -266,7 +266,7 @@ var
           for k := 1 to TokenAt(i).StrLength do
             nam := nam + chr(StaticStringData[TokenAt(i).StrAddress - CODEORIGIN + k]);
 
-          nam := FindFile(nam, 'unit');
+          nam := FindFile(LowerCase(nam), 'unit');
 
           Dec(i, 2);
 
@@ -276,7 +276,7 @@ var
 
           CheckTok(i, TTokenKind.IDENTTOK);
 
-          nam := FindFile(TokenAt(i).Name + '.pas', 'unit');
+          nam := FindFile(LowerCase(TokenAt(i).Name) + '.pas', 'unit');
 
         end;
 


### PR DESCRIPTION
Fix for Linux path issue https://github.com/tebe6502/Mad-Pascal/issues/215

I have created a PR which solves the problem on Linux with some tradeoffs. With the PR the path remains as-is (will not be converted) and the unit name is always converted to lower-case for `FindFile(..., 'unit')`. So on Linux (and on other case-sensitive OSes), the unit filenames must always be written in lower-case. e.g. `usprite.pas` 