### PR TITLE
Way2js4 - Activate Range Checks

### DIFF
--- a/projects/MakeMadPascal.bat
+++ b/projects/MakeMadPascal.bat
@@ -1,10 +1,37 @@
-@echo off
+@echo on
 cd %~dp0
-rem Replace .WinMerge ^ .pas ^
+rem Replace .WinMerge .pas ^
 rem Replace C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\ -inputFilePattern
 MakeMadPascal.exe -allThreads -allFiles -mpFolderPath .\.. -compileReference -compile -compare -openResults ^
 -referenceMPExePath C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\bin\windows_x86_64\origin\mp.exe ^
--mpExePath C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\bin\windows_x86_64\mp.exe ^
+-mpExePath C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\projects\TestMadPascal.exe ^
+-inputFilePattern samples\a8\compression\apl\unapl.pas ^
+-inputFilePattern samples\a8\compression\deflate\undef.pas ^
+-inputFilePattern samples\a8\compression\lz4\unlz4.pas ^
+-inputFilePattern samples\a8\compression\packfire\pcf_test.pas ^
+-inputFilePattern samples\a8\compression\pp\test.pas ^
+-inputFilePattern samples\a8\compression\pp\test_handle.pas ^
+-inputFilePattern samples\a8\compression\upkr\test_upk.pas ^
+-inputFilePattern samples\a8\compression\zx0\unzx0.pas ^
+-inputFilePattern samples\a8\compression\zx2\unzx2.pas ^
+-inputFilePattern samples\a8\compression\zx5\unzx5.pas ^
+-inputFilePattern samples\a8\demoeffects\crosses_r.pas ^
+-inputFilePattern samples\a8\displaylist\dl_create.pas ^
+-inputFilePattern samples\a8\extra_ram\vscrol.pas ^
+-inputFilePattern samples\a8\games\hitbox\hitbox2.pas ^
+-inputFilePattern samples\a8\graph_vbxe\view.pas ^
+-inputFilePattern samples\a8\graph_vbxe\gif\gifview.pas ^
+-inputFilePattern samples\a8\graph_vbxe_ansi\test_ansi.pas ^
+-inputFilePattern samples\a8\math\sorting\sortalg.tp.pas ^
+-inputFilePattern samples\common\extreal.pas ^
+-inputFilePattern samples\tests\tests-basic\negative-index-range.pas ^
+-inputFilePattern samples\tests\tests-medium\array-with-char-index.pas ^
+-inputFilePattern samples\tests\tests-while\while_lteq.pas ^
+-inputFilePattern samples\vic-20\snake\vic20.pas ^
+
+
+goto :eof
+
 -inputFilePattern samples\a8\games\mine.pas ^
 -inputFilePattern samples\a8\games\hitbox\hitbox2.pas ^
 -inputFilePattern samples\a8\graph_vbxe\gif\gifview.pas ^

--- a/projects/MakeMadPascal.lpi
+++ b/projects/MakeMadPascal.lpi
@@ -36,7 +36,7 @@
         </Mode>
         <Mode Name="all">
           <local>
-            <CommandLineParams Value="-allThreads -allFiles -compileReference -compile -compare -openResults -waitForKey -inputFilePattern bracket"/>
+            <CommandLineParams Value="-allThreads -allFiles -compileReference -compile -compare -openResults -waitForKey -inputFilePattern suite"/>
           </local>
         </Mode>
       </Modes>
@@ -127,15 +127,19 @@
     <Exceptions>
       <Item>
         <Name Value="EAbort"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="ECodetoolError"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="EFOpenError"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="THaltException"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="ERangeError"/>
@@ -143,12 +147,15 @@
       </Item>
       <Item>
         <Name Value="RunError(201)"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="EEValuationException"/>
+        <Enabled Value="False"/>
       </Item>
       <Item>
         <Name Value="EProcess"/>
+        <Enabled Value="False"/>
       </Item>
     </Exceptions>
   </Debugging>

--- a/projects/MakeMadPascal.lpr
+++ b/projects/MakeMadPascal.lpr
@@ -594,7 +594,7 @@ type
       if (Lines.Count < 3) then
       begin
         Log(fileResult, Format('ERROR: %s', [a65FilePath]));
-        Log(fileResult, 'ERROR: Not enough lines in output.');
+        Log(fileResult, 'ERROR: There are not enough lines in the output file.');
         EXIT(False);
       end;
 

--- a/projects/TestMadPascal.lpi
+++ b/projects/TestMadPascal.lpi
@@ -26,8 +26,8 @@
       <Modes>
         <Mode Name="default">
           <local>
-            <CommandLineParams Value="-iPath:C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\lib test_ansi.pas"/>
-            <WorkingDirectory Value="C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\samples\a8\graph_vbxe_ansi"/>
+            <CommandLineParams Value="-iPath:C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\lib -iPath:C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\blibs while_lteq.pas"/>
+            <WorkingDirectory Value="C:\jac\system\Atari800\Programming\Repositories\Mad-Pascal\samples\tests\tests-while\"/>
           </local>
         </Mode>
         <Mode Name="samples">
@@ -610,6 +610,7 @@
       <SyntaxOptions>
         <SyntaxMode Value="Delphi"/>
         <IncludeAssertionCode Value="True"/>
+        <AllowLabel Value="False"/>
       </SyntaxOptions>
     </Parsing>
     <CodeGeneration>

--- a/src/Compiler.pas
+++ b/src/Compiler.pas
@@ -1140,7 +1140,8 @@ end;  //LoadBP2
 // ----------------------------------------------------------------------------
 
 
-procedure Push(Value: Int64; IndirectionLevel: Byte; Size: Byte; IdentIndex: Integer = 0; par: Byte = 0);
+procedure Push(Value: Int64; IndirectionLevel: TIndirectionLevel; Size: Byte;
+  IdentIndex: TIdentifierIndex = 0; par: Byte = 0);
 var
   Kind: TTokenKind;
   NumAllocElements: Cardinal;
@@ -8443,7 +8444,8 @@ begin
     asm65(#9'inx');
 
     ActualParamType := IdentifierAt(IdentIndex).DataType;
-    if ActualParamType = TDataType.ENUMTOK then ActualParamType := IdentifierAt(IdentIndex).NestedFunctionAllocElementType;
+    if ActualParamType = TDataType.ENUMTOK then
+      ActualParamType := IdentifierAt(IdentIndex).NestedFunctionAllocElementType;
 
     case GetDataSize(ActualParamType) of
 
@@ -10033,7 +10035,8 @@ begin
                 CompileActualParameters(i, IdentIndex);
 
                 ValType := IdentifierAt(IdentIndex).DataType;
-                if (ValType = TDataType.ENUMTOK) then ValType := IdentifierAt(IdentIndex).NestedFunctionAllocElementType;
+                if (ValType = TDataType.ENUMTOK) then
+                  ValType := IdentifierAt(IdentIndex).NestedFunctionAllocElementType;
 
                 Dec(run_func);
 
@@ -10322,8 +10325,11 @@ begin
                                 if GetDataSize(ValType) > GetDataSize(VarType) then ValType := VarType;
                               end;
 
-                              Push(IdentifierAt(IdentIndex).Value, IndirectionLevel, GetDataSize(ValType),
-                                IdentIndex, IdentTemp and $ffff);
+                              Push(IdentifierAt(IdentIndex).Value, IndirectionLevel,
+                                GetDataSize(ValType), IdentIndex, IdentTemp and $ff);
+// TODO: To be checked by tebe
+//                              Push(IdentifierAt(IdentIndex).Value, IndirectionLevel,
+//                              GetDataSize(ValType), IdentIndex, IdentTemp and $ffff);
 
                               CheckTok(i + 1, TTokenKind.CBRACKETTOK);
 
@@ -13364,12 +13370,11 @@ begin
       i := CompileExpression(i + 1, SelectorType);
 
 
-      if (TokenAt(j).Kind = TTokenKind.IDENTTOK) and
-         (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).Kind = TTokenKind.FUNCTIONTOK) and
-	 (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).DataType = TDatatype.ENUMTOK) then
+      if (TokenAt(j).Kind = TTokenKind.IDENTTOK) and (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).Kind =
+        TTokenKind.FUNCTIONTOK) and (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).DataType = TDatatype.ENUMTOK) then
 
-//      if (SelectorType = TDatatype.ENUMTOK) and (TokenAt(j).Kind = TTokenKind.IDENTTOK) and
-//      (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).Kind = TTokenKind.FUNCTIONTOK) then
+        //      if (SelectorType = TDatatype.ENUMTOK) and (TokenAt(j).Kind = TTokenKind.IDENTTOK) and
+        //      (IdentifierAt(GetIdentIndex(TokenAt(j).Name)).Kind = TTokenKind.FUNCTIONTOK) then
       begin
 
         IdentTemp := GetIdentIndex(TokenAt(j).Name);

--- a/src/Debugger.pas
+++ b/src/Debugger.pas
@@ -44,7 +44,11 @@ end;
 
 function TDebugger.isActive: Boolean;
 begin
+  {$IFDEF DEBUG}
   Result := True;
+  {$ELSE}
+  Result := False;
+  {$ENDIF}
 end;
 
 procedure TDebugger.LogDebug(const message: String);

--- a/src/Defines.inc
+++ b/src/Defines.inc
@@ -1,8 +1,5 @@
 {$ASSERTIONS ON}
-
-// TODO: There are still cases where ranges need to be ignored, e.g. TFloat conversions
-//{$RANGECHECKS ON}
-{$RANGECHECKS OFF}
+{$RANGECHECKS ON}
 
 //{$DEFINE WHILEDO}
 

--- a/src/FileIO.pas
+++ b/src/FileIO.pas
@@ -712,7 +712,6 @@ begin
     Result := StringReplace(filePath, '\', '/', [rfReplaceAll]);
    end;
 
-  Result := LowerCase(Result);
   {$ENDIF}
 
   {$IFDEF SIMULATED_FILE_IO}
@@ -721,7 +720,6 @@ begin
     Result := StringReplace(filePath, '\', '/', [rfReplaceAll]);
    end;
 
-  Result := LowerCase(Result);
   {$ENDIF}
 
 end;

--- a/src/Makefile.bat
+++ b/src/Makefile.bat
@@ -3,7 +3,7 @@ rem
 rem Windows Makefile for PAS2JS and verification of regression tests during refactorings.
 rem
 rem Set %WUDSN_TOOLS_FOLDER% to the folder with the latest https://github.com/wudsn/wudsn-ide-tools
-re, The script will use the FPC, MP, and MADS versions from there as a reference.
+rem The script will use the FPC, MP, and MADS versions from there as a reference.
 rem
 rem The script compiles "Test-0.pas" with FPC vs. the new MP.
 rem The script compiles a set of reference examples with the released and the new MP and validates that there are no differences in the binary output.

--- a/src/Numbers.pas
+++ b/src/Numbers.pas
@@ -51,7 +51,9 @@ end;
 
 function ToTFloat(const s: Single): TFloat; overload;
 begin
+  {$RANGECHECKS OFF}
   Result[0] := round(s * TWOPOWERFRACBITS);
+  {$RANGECHECKS ON}
   {$IFNDEF PAS2JS}
   Result[1] := Integer(s);
   {$ENDIF}
@@ -221,7 +223,9 @@ function CardToHalf(const ftmp: TFloat): Word; overload;
 var
   Value: Uint32;
 begin
+{$RANGECHECKS OFF}
   Value := ftmp[1];
+{$RANGECHECKS ON}
   Result := CardToHalf32(Value);
 end;
 

--- a/src/Optimize.pas
+++ b/src/Optimize.pas
@@ -77,8 +77,8 @@ var
 
       for ChildIndex := 1 to CallGraph[ProcAsBlockIndex].NumChildren do
         for ChildIdentIndex := 1 to NumIdent do
-          if (IdentifierAt(ChildIdentIndex).ProcAsBlock > 0) and (IdentifierAt(ChildIdentIndex).ProcAsBlock =
-            CallGraph[ProcAsBlockIndex].ChildBlock[ChildIndex]) then
+          if (IdentifierAt(ChildIdentIndex).ProcAsBlock > 0) and
+            (IdentifierAt(ChildIdentIndex).ProcAsBlock = CallGraph[ProcAsBlockIndex].ChildBlock[ChildIndex]) then
             MarkNotDead(ChildIdentIndex);
 
     end;
@@ -112,10 +112,9 @@ var
   function fail(i: Integer): Boolean;
   begin
 
-    if (pos('#asm:', TemporaryBuf[i]) = 1) or ldy(i) or jsr(i) or
-      iny(i) or dey(i) or tay(i) or tya(i) or mwy(i) or
-      mwy(i) or (pos(#9'.if', TemporaryBuf[i]) > 0) or (pos(#9'.LOCAL ', TemporaryBuf[i]) > 0) or
-      (pos(#9'@print', TemporaryBuf[i]) > 0) then Result := True
+    if (pos('#asm:', TemporaryBuf[i]) = 1) or ldy(i) or jsr(i) or iny(i) or dey(i) or
+      tay(i) or tya(i) or mwy(i) or mwy(i) or (pos(#9'.if', TemporaryBuf[i]) > 0) or
+      (pos(#9'.LOCAL ', TemporaryBuf[i]) > 0) or (pos(#9'@print', TemporaryBuf[i]) > 0) then Result := True
     else
       Result := False;
   end;
@@ -124,10 +123,11 @@ var
   function SKIP(i: Integer): Boolean;
   begin
 
-    Result := seq(i) or sne(i) or spl(i) or smi(i) or scc(i) or scs(i) or svc(i) or
-      svs(i) or jne(i) or jeq(i) or jcc(i) or jcs(i) or jmi(i) or jpl(i) or (pos(#9'bne ', TemporaryBuf[i]) = 1) or
+    Result := seq(i) or sne(i) or spl(i) or smi(i) or scc(i) or scs(i) or svc(i) or svs(i) or
+      jne(i) or jeq(i) or jcc(i) or jcs(i) or jmi(i) or jpl(i) or (pos(#9'bne ', TemporaryBuf[i]) = 1) or
       (pos(#9'beq ', TemporaryBuf[i]) = 1) or (pos(#9'bcc ', TemporaryBuf[i]) = 1) or
-      (pos(#9'bcs ', TemporaryBuf[i]) = 1) or (pos(#9'bmi ', TemporaryBuf[i]) = 1) or (pos(#9'bpl ', TemporaryBuf[i]) = 1);
+      (pos(#9'bcs ', TemporaryBuf[i]) = 1) or (pos(#9'bmi ', TemporaryBuf[i]) = 1) or
+      (pos(#9'bpl ', TemporaryBuf[i]) = 1);
   end;
 
 
@@ -189,7 +189,7 @@ var
     a := TemporaryBuf[j];
 
     if a <> '' then
-      while not (a[i] in [' ', #9]) and (i <= length(a)) do
+      while (i <= length(a)) and not (a[i] in [' ', #9]) do
       begin
         Result := Result + a[i];
         Inc(i);
@@ -576,6 +576,14 @@ var
     Result := GetVAL(copy(listing[i], 6, 4)) + GetVAL(copy(listing[j], 6, 4)) shl 8;
   end;
 
+  function GetDWORD(i, j, k, l: Integer): Cardinal;
+  var
+    w1, w2: Cardinal;
+  begin
+    w1 := GetWORD(i, j);
+    w2 := GetWORD(k, l);
+    Result := w1 + w2 shl 16;
+  end;
 
 {$i include/cmd_listing.inc}
 
@@ -1740,9 +1748,9 @@ end;
 
 
         if (i = l - 4) and                    // "samotna" instrukcja na koncu bloku
-          lda_val(i + 1) and sta_a(i + 2) and sta_a(i + 3) and (lda_a(i) or
-          and_ora_eor(i) or lsr_stack(i) or asl_stack(i) or ror_stack(i) or rol_stack(i) or
-          lsr_a(i) or asl_a(i) or ror_a(i) or rol_a(i)) then
+          lda_val(i + 1) and sta_a(i + 2) and sta_a(i + 3) and (lda_a(i) or and_ora_eor(i) or
+          lsr_stack(i) or asl_stack(i) or ror_stack(i) or rol_stack(i) or lsr_a(i) or asl_a(i) or
+          ror_a(i) or rol_a(i)) then
         begin
           listing[i] := '';
 
@@ -2176,7 +2184,8 @@ end;
         end;
 
 
-      if (and_ora_eor(i) or asl_a(i) or rol_a(i) or lsr_a(i) or ror_a(i)) and (iy(i) = False) and  // and|ora|eor      ; 0
+      if (and_ora_eor(i) or asl_a(i) or rol_a(i) or lsr_a(i) or ror_a(i)) and (iy(i) = False) and
+        // and|ora|eor      ; 0
         sta_stack(i + 1) and                  // sta :STACKORIGIN+N    ; 1
         ldy_1(i + 2) and                    // ldy #1      ; 2
         lda_stack(i + 3) and                   // lda :STACKORIGIN+N    ; 3
@@ -2861,8 +2870,9 @@ begin        // OptimizeASM
                                           end;
 
 
-                                          if lda_im(l) and (listing[l + 1] = #9'sta :ecx') and lda_im(l + 2) and
-                                            (listing[l + 3] = #9'sta :ecx+1') and lda_im(l + 4) and sta_eax(l + 5) and lda_im(l + 6) and
+                                          if lda_im(l) and (listing[l + 1] = #9'sta :ecx') and
+                                            lda_im(l + 2) and (listing[l + 3] = #9'sta :ecx+1') and
+                                            lda_im(l + 4) and sta_eax(l + 5) and lda_im(l + 6) and
                                             sta_eax_1(l + 7) then
                                           begin
 
@@ -2938,7 +2948,8 @@ begin        // OptimizeASM
                                           (listing[m + 1] = #9'sta :ecx') and             // sta :ecx        ; 1
                                             lda_im_0(m + 2) and                // lda #$00        ; 2
                                             (listing[m + 3] = #9'sta :ecx+1') and             // sta :ecx+1        ; 3
-                                            lda_a(m + 4) and {(lda_stack(m+4) = false) and}          // lda           ; 4
+                                            lda_a(m + 4) and {(lda_stack(m+4) = false) and}
+                                            // lda           ; 4
                                             sta_eax(m + 5) and                  // sta :eax        ; 5
                                             lda_im_0(m + 6) and                // lda #$00        ; 6
                                             sta_eax_1(m + 7) and                // sta :eax+1        ; 7
@@ -3152,7 +3163,8 @@ begin        // OptimizeASM
                                                               else
 
 
-                                                                if (pos('add', arg0) > 0) or (pos('sub', arg0) > 0) then
+                                                                if (pos('add', arg0) > 0) or
+                                                                  (pos('sub', arg0) > 0) then
                                                                 begin
 
                                                                   t := '';
@@ -3257,7 +3269,8 @@ begin        // OptimizeASM
                                                                   if elf = $0A86250C then
                                                                   begin    // addAL_CL
 
-                                                                    if (pos(',y', s[x - 1][0]) > 0) or (pos(',y', s[x][0]) > 0) then
+                                                                    if (pos(',y', s[x - 1][0]) > 0) or
+                                                                      (pos(',y', s[x][0]) > 0) then
                                                                     begin
                                                                       x := 30;
                                                                       Break;
@@ -3365,106 +3378,150 @@ begin        // OptimizeASM
                                                                   if elf = $004746C5 then    // @move    accepted
                                                                   else
 
-                                                                    if elf = $058D0867 then    // @cmpSTRING    accepted
+                                                                    if elf = $058D0867 then
+                                                                    // @cmpSTRING    accepted
                                                                     else
-                                                                    if elf = $03CEEED7 then		// @cmpCHAR2STRING	accepted
-                                                                    else
-                                                                    if elf = $06FEACE2 then		// @cmpSTRING2CHAR	accepted
-                                                                     else
-                                                                      if elf = $044A824C then    // @FCMPL    accepted
+                                                                      if elf = $03CEEED7 then
+                                                                      // @cmpCHAR2STRING  accepted
                                                                       else
-
-                                                                        if elf = $0044B931 then    // @FTOA    accepted
+                                                                        if elf = $06FEACE2 then
+                                                                        // @cmpSTRING2CHAR  accepted
                                                                         else
-
-                                                                          if elf = $094C6F26 then    // @SHORTINT.DIV  accepted
+                                                                          if elf = $044A824C then    // @FCMPL    accepted
                                                                           else
-                                                                            if elf = $09B849A6 then    // @SMALLINT.DIV  accepted
+
+                                                                            if elf = $0044B931 then    // @FTOA    accepted
                                                                             else
-                                                                              if elf = $0FEB1076 then    // @INTEGER.DIV    accepted
+
+                                                                              if elf = $094C6F26 then
+                                                                              // @SHORTINT.DIV  accepted
                                                                               else
-                                                                                if elf = $094C77F4 then    // @SHORTINT.MOD  accepted
+                                                                                if elf = $09B849A6 then
+                                                                                // @SMALLINT.DIV  accepted
                                                                                 else
-                                                                                  if elf = $09B85174 then    // @SMALLINT.MOD  accepted
+                                                                                  if elf = $0FEB1076 then
+                                                                                  // @INTEGER.DIV    accepted
                                                                                   else
-                                                                                    if elf = $0FEB2AA4 then    // @INTEGER.MOD    accepted
+                                                                                    if elf = $094C77F4 then
+                                                                                    // @SHORTINT.MOD  accepted
                                                                                     else
-
-                                                                                      if elf = $0E886C96 then    // @BYTE.DIV    accepted
+                                                                                      if elf = $09B85174 then
+                                                                                      // @SMALLINT.MOD  accepted
                                                                                       else
-                                                                                        if elf = $04676D26 then    // @WORD.DIV    accepted
+                                                                                        if elf = $0FEB2AA4 then
+                                                                                        // @INTEGER.MOD    accepted
                                                                                         else
-                                                                                          if elf = $06294046 then    // @CARDINAL.DIV  accepted
+
+                                                                                          if elf = $0E886C96 then
+                                                                                          // @BYTE.DIV    accepted
                                                                                           else
-                                                                                            if elf = $0E887644 then    // @BYTE.MOD    accepted
+                                                                                            if elf = $04676D26 then
+                                                                                            // @WORD.DIV    accepted
                                                                                             else
-                                                                                              if elf = $046775F4 then    // @WORD.MOD    accepted
+                                                                                              if elf = $06294046 then
+                                                                                              // @CARDINAL.DIV  accepted
                                                                                               else
-                                                                                                if elf = $06295A94 then    // @CARDINAL.MOD  accepted
+                                                                                                if elf = $0E887644 then
+                                                                                                // @BYTE.MOD    accepted
                                                                                                 else
-
-                                                                                                  if elf = $0E965FAC then    // @SHORTREAL_MUL  accepted
+                                                                                                  if elf = $046775F4 then
+                                                                                                  // @WORD.MOD    accepted
                                                                                                   else
-                                                                                                    if elf = $096287FC then    // @REAL_MUL    accepted
+                                                                                                    if elf = $06295A94 then
+                                                                                                    // @CARDINAL.MOD  accepted
                                                                                                     else
-                                                                                                      if elf = $0E9645D6 then    // @SHORTREAL_DIV  accepted
+
+                                                                                                      if elf =
+                                                                                                        $0E965FAC then
+                                                                                                      // @SHORTREAL_MUL  accepted
                                                                                                       else
-                                                                                                        if elf = $09627D86 then    // @REAL_DIV    accepted
+                                                                                                        if elf =
+                                                                                                          $096287FC then    // @REAL_MUL    accepted
                                                                                                         else
-
-                                                                                                          if elf = $02042144 then    // @REAL_ROUND    accepted
+                                                                                                          if elf =
+                                                                                                            $0E9645D6 then    // @SHORTREAL_DIV  accepted
                                                                                                           else
-                                                                                                            if elf = $063448B3 then    // @SHORTREAL_TRUNC  accepted
+                                                                                                            if elf =
+                                                                                                              $09627D86 then    // @REAL_DIV    accepted
                                                                                                             else
-                                                                                                              if elf = $020C1143 then    // @REAL_TRUNC    accepted
+
+                                                                                                              if elf =
+                                                                                                                $02042144 then    // @REAL_ROUND    accepted
                                                                                                               else
-                                                                                                                if elf = $0627E0C3 then    // @REAL_FRAC    accepted
+                                                                                                                if elf =
+                                                                                                                  $063448B3 then    // @SHORTREAL_TRUNC  accepted
                                                                                                                 else
-
-                                                                                                                  if elf = $0044B29C then    // @FMUL    accepted
+                                                                                                                  if elf =
+                                                                                                                    $020C1143 then    // @REAL_TRUNC    accepted
                                                                                                                   else
-                                                                                                                    if elf = $0044A8E6 then    // @FDIV    accepted
+                                                                                                                    if
+                                                                                                                    elf = $0627E0C3 then    // @REAL_FRAC    accepted
                                                                                                                     else
-                                                                                                                      if elf = $0044A584 then    // @FADD    accepted
+
+                                                                                                                      if elf
+                                                                                                                        = $0044B29C then    // @FMUL    accepted
                                                                                                                       else
-                                                                                                                        if elf = $0044B892 then    // @FSUB    accepted
+                                                                                                                        if elf
+                                                                                                                          = $0044A8E6 then    // @FDIV    accepted
                                                                                                                         else
-                                                                                                                          if elf = $00044C66 then    // @I2F      accepted
+                                                                                                                          if
+                                                                                                                          elf = $0044A584 then    // @FADD    accepted
                                                                                                                           else
-                                                                                                                            if elf = $00044969 then    // @F2I      accepted
+                                                                                                                            if
+                                                                                                                            elf = $0044B892 then    // @FSUB    accepted
                                                                                                                             else
-                                                                                                                              if elf = $044AB653 then    // @FFRAC    accepted
+                                                                                                                              if
+                                                                                                                              elf = $00044C66 then    // @I2F      accepted
                                                                                                                               else
-                                                                                                                                if elf = $04B74A64 then    // @FROUND    accepted
+                                                                                                                                if
+                                                                                                                                elf = $00044969 then    // @F2I      accepted
                                                                                                                                 else
-
-                                                                                                                                  if elf = $094C3D21 then    // @F16_F2A    accepted
+                                                                                                                                  if
+                                                                                                                                  elf = $044AB653 then    // @FFRAC    accepted
                                                                                                                                   else
-                                                                                                                                    if elf = $094C31C4 then    // @F16_ADD    accepted
+                                                                                                                                    if
+                                                                                                                                    elf = $04B74A64 then    // @FROUND    accepted
                                                                                                                                     else
-                                                                                                                                      if elf = $094C4CD2 then     // @F16_SUB    accepted
+
+                                                                                                                                      if
+                                                                                                                                      elf = $094C3D21 then    // @F16_F2A    accepted
                                                                                                                                       else
-                                                                                                                                        if elf = $094C46DC then    // @F16_MUL    accepted
+                                                                                                                                        if
+                                                                                                                                        elf = $094C31C4 then    // @F16_ADD    accepted
                                                                                                                                         else
-                                                                                                                                          if elf = $094C3CA6 then    // @F16_DIV    accepted
+                                                                                                                                          if
+                                                                                                                                          elf = $094C4CD2 then     // @F16_SUB    accepted
                                                                                                                                           else
-                                                                                                                                            if elf = $094C3A74 then    // @F16_INT    accepted
+                                                                                                                                            if
+                                                                                                                                            elf = $094C46DC then    // @F16_MUL    accepted
                                                                                                                                             else
-                                                                                                                                              if elf = $0C430164 then    // @F16_ROUND    accepted
-                                                                          else
-                                                                                                                                                if elf = $04C3F2C3 then    // @F16_FRAC    accepted
-                                                                            else
-                                                                                                                                                  if elf = $094C3826 then    // @F16_I2F    accepted
-                                                                              else
-                                                                                                                                                    if elf = $0494C3E1 then    // @F16_EQ    accepted
-                                                                                  else
-                                                                                                                                                      if elf = $0494C384 then    // @F16_GT    accepted
-                                                                                    else
-                                                                                                                                                        if elf = $094C38C5 then    // @F16_GTE    accepted
-
-
+                                                                                                                                              if
+                                                                                                                                              elf = $094C3CA6 then    // @F16_DIV    accepted
+                                                                                                                                              else
+                                                                                                                                                if
+                                                                                                                                                elf = $094C3A74 then    // @F16_INT    accepted
+                                                                                                                                                else
+                                                                                                                                                  if
+                                                                                                                                                  elf = $0C430164 then    // @F16_ROUND    accepted
+                                                                                                                                                  else
+                                                                                                                                                    if
+                                                                                                                                                    elf = $04C3F2C3 then    // @F16_FRAC    accepted
+                                                                                                                                                    else
+                                                                                                                                                      if
+                                                                                                                                                      elf = $094C3826 then    // @F16_I2F    accepted
+                                                                                                                                                      else
+                                                                                                                                                        if
+                                                                                                                                                        elf = $0494C3E1 then    // @F16_EQ    accepted
                                                                                                                                                         else
-                                                                                                                                                        begin
+                                                                                                                                                          if
+                                                                                                                                                          elf = $0494C384 then    // @F16_GT    accepted
+                                                                                                                                                          else
+                                                                                                                                                            if
+                                                                                                                                                            elf = $094C38C5 then    // @F16_GTE    accepted
+
+
+                                                                                                                                                            else
+                                                                                                                                                            begin
 
 {$IFDEF USEOPTFILE}
 
@@ -3472,10 +3529,11 @@ begin        // OptimizeASM
 
 {$ENDIF}
 
-                                                                                                                                                          x := 51;
-                                                                                                                                                          Break;
+                                                                                                                                                              x :=
+                                                                                                                                                                51;
+                                                                                                                                                              Break;
 
-                                                                                                                                                        end;
+                                                                                                                                                            end;
 
       end;
 
@@ -3723,7 +3781,8 @@ begin        // OptimizeASM
 
     if optyA <> '' then
       for i := 0 to l - 1 do
-        if (listing[i] = #9'inc ' + optyA) or (listing[i] = #9'dec ' + optyA) or //((optyY <> '') and (optyA = optyY)) or
+        if (listing[i] = #9'inc ' + optyA) or (listing[i] = #9'dec ' + optyA) or
+          //((optyY <> '') and (optyA = optyY)) or
           lda_a(i) or mva(i) or mwa(i) or tya(i) or lab_a(i) or jsr(i) or (pos(#9'jmp ', listing[i]) > 0) or
           (pos(#9'.if', listing[i]) > 0) then
         begin

--- a/src/StringUtilities.pas
+++ b/src/StringUtilities.pas
@@ -157,8 +157,8 @@ begin
 
     SkipWhitespaces(a, i);
 
-    if UpCase(a[i]) in AllowLabelFirstChars + ['.'] then
-      while UpCase(a[i]) in AllowLabelChars + AllowDirectorySeparators do
+    if (i <= length(a)) and (UpCase(a[i]) in AllowLabelFirstChars + ['.']) then
+      while (i <= length(a)) and (UpCase(a[i]) in (AllowLabelChars + AllowDirectorySeparators)) do
       begin
 
         if upperCase then
@@ -190,52 +190,54 @@ end;
 (*----------------------------------------------------------------------------*)
 function GetString(const a: String; const upperCase: Boolean; var i: TStringIndex): String;
 var
-  len: Integer;
   znak, gchr: Char;
 begin
   Result := '';
 
   SkipWhitespaces(a, i);
 
-  if a[i] = '%' then
+  if (i <= length(a)) then
   begin
 
-    while UpCase(a[i]) in ['A'..'Z', '%'] do
-    begin
-      Result := Result + Upcase(a[i]);
-      Inc(i);
-    end;
-
-  end
-  else
-    if not (a[i] in AllowQuotes) then
+    if a[i] = '%' then
     begin
 
-      Result := GetLabel(a, upperCase, i);
+      while (i <= length(a)) and (UpCase(a[i]) in ['A'..'Z', '%']) do
+      begin
+        Result := Result + Upcase(a[i]);
+        Inc(i);
+      end;
 
     end
     else
-    begin
-
-      gchr := a[i];
-      len := length(a);
-
-      while i <= len do
+      if not (a[i] in AllowQuotes) then
       begin
-        Inc(i);   // we skip the first character ' or "
 
-        znak := a[i];
+        Result := GetLabel(a, upperCase, i);
 
-        if znak = gchr then
+      end
+      else
+      begin
+
+        gchr := a[i];
+
+        while (i <= length(a)) do
         begin
-          Inc(i);
-          Break;
+          Inc(i);   // we skip the first character ' or "
+
+          znak := a[i];
+
+          if znak = gchr then
+          begin
+            Inc(i);
+            Break;
+          end;
+
+          Result := Result + znak;
         end;
 
-        Result := Result + znak;
       end;
-
-    end;
+  end;
 
 end;
 

--- a/src/include/opt6502/opt_CMP_GT.inc
+++ b/src/include/opt6502/opt_CMP_GT.inc
@@ -60,7 +60,7 @@ begin
        lda_a(i+9) and										// lda W		; 9
        cmp_im(i+10) then									// cmp #$00		; 10
       begin
-       c:=GetByte(i+10) + GetByte(i+7) shl 8 + GetByte(i+4) shl 16 + GetByte(i+1) shl 24;
+       c := GetDWORD(i+10, i+7, i+4, i+1);
 
        if c = 0 then begin
         listing[i+1] := '';

--- a/src/include/opt6502/opt_END_STA.inc
+++ b/src/include/opt6502/opt_END_STA.inc
@@ -647,7 +647,8 @@
 	for p:=i-1 downto 0 do
 	 if listing[p] = tmp then begin
 
-	  if (listing[p-3] = listing[i]) and				// mwy   :bp2			; -3
+	  if (p >= 3) and
+             (listing[p-3] = listing[i]) and				// mwy   :bp2			; -3
 	     (listing[p-2] = listing[i+1]) and				// ldy				; -2
 	     lda_bp2_y(p-1) and						// lda (:bp2),y			; -1
 	     iny(p+1) and						// sta :STACKORIGIN+9		; 0

--- a/src/include/opt6502/opt_SPL.inc
+++ b/src/include/opt6502/opt_SPL.inc
@@ -18,6 +18,7 @@ begin
 //       spl(i+2) and										// spl					; 2
        dey(i+3) then										// dey					; 3
      begin
+        err:=0;
 	val(copy(listing[i+1], 7, 256), p, err);
 
 	listing[i+2] := '';


### PR DESCRIPTION
We still had many places where the array indexes and intermediate value were out of range and the result were really undefined. For example in the optimize you would access lines that are not in the array, or we'd parse characters after the end of the line or SHL on Integer exceeds High(Cardinal) when reading a DWORD.